### PR TITLE
Release 0.8.0

### DIFF
--- a/src/Extensions/KuboBasedNomadStorageExtensions.cs
+++ b/src/Extensions/KuboBasedNomadStorageExtensions.cs
@@ -25,7 +25,7 @@ public static class KuboBasedNomadStorageExtensions
     /// <param name="eventEntry">The event entry to apply to the given <paramref name="file"/>.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <exception cref="InvalidOperationException">Raised when the <see cref="EventStreamEntry{TContentPointer}.TargetId"/> doesn't match the <see cref="OwlCore.Storage.IStorable.Id"/> of the provided <paramref name="file"/>.</exception>
-    public static async Task TryAdvanceEventStreamAsync(this IReadOnlyKuboBasedNomadFile file, EventStreamEntry<Cid> eventEntry, CancellationToken cancellationToken)
+    public static async Task TryAdvanceEventStreamAsync(this IModifiableKuboNomadFile file, EventStreamEntry<Cid> eventEntry, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         
@@ -48,7 +48,7 @@ public static class KuboBasedNomadStorageExtensions
     /// <param name="eventEntry">The event entry to apply to the given <paramref name="folder"/>.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <exception cref="InvalidOperationException">Raised when the <see cref="EventStreamEntry{TContentPointer}.TargetId"/> doesn't match the <see cref="OwlCore.Storage.IStorable.Id"/> of the provided <paramref name="folder"/>.</exception>
-    public static async Task TryAdvanceEventStreamAsync(this IReadOnlyKuboBasedNomadFolder folder, EventStreamEntry<Cid> eventEntry, CancellationToken cancellationToken)
+    public static async Task TryAdvanceEventStreamAsync(this IModifiableKuboNomadFolder folder, EventStreamEntry<Cid> eventEntry, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         
@@ -74,7 +74,7 @@ public static class KuboBasedNomadStorageExtensions
     /// <param name="nomadFile">The file to operate in.</param>
     /// <param name="updateEvent">The event content to apply without side effects.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing task.</param>
-    public static Task ApplyFileUpdateAsync(this IReadOnlyKuboBasedNomadFile nomadFile, FileUpdateEvent updateEvent, CancellationToken cancellationToken)
+    public static Task ApplyFileUpdateAsync(this IReadOnlyKuboNomadFile nomadFile, FileUpdateEvent updateEvent, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
 
@@ -86,75 +86,6 @@ public static class KuboBasedNomadStorageExtensions
         nomadFile.Inner.ContentId = updateEvent.NewContentId;
         Guard.IsNotEqualTo("QmbFMke1KXqnYyBBWxB74N4c5SBnJMVAiMNRcGu6x1AwQH", updateEvent.NewContentId.ToString());
         return Task.CompletedTask;
-    }
-
-    /// <summary>
-    /// Applies the provided <paramref name="updateEvent"/> in the provided <paramref name="nomadFolder"/>.
-    /// </summary>
-    /// <param name="nomadFolder">The folder to operate in.</param>
-    /// <param name="updateEvent">The event content to apply without side effects.</param>
-    /// <param name="cancellationToken">A token that can be used to cancel the ongoing task.</param>
-    public static Task<NomadStorableData?> ApplyFolderUpdateAsync(this IReadOnlyKuboBasedNomadFolder nomadFolder, CreateFileInFolderEvent updateEvent, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-        
-        var existing = nomadFolder.Inner.Files.FirstOrDefault(x =>
-            x.StorableItemId == updateEvent.StorableItemId ||
-            x.StorableItemName == updateEvent.StorableItemName);
-
-        if (updateEvent.Overwrite && existing is not null)
-        {
-            nomadFolder.Inner.Files.Remove(existing);
-            existing = null;
-        }
-
-        var nomadFileData = existing ?? new NomadFileData<Cid>
-        {
-            ContentId = null,
-            StorableItemId = updateEvent.StorableItemId,
-            StorableItemName = updateEvent.StorableItemName,
-        };
-        
-        if (nomadFolder.Inner.Files.All(x => x.StorableItemId != nomadFileData.StorableItemId))
-            nomadFolder.Inner.Files.Add(nomadFileData);
-        
-        return Task.FromResult<NomadStorableData?>(nomadFileData);
-    }
-
-    /// <summary>
-    /// Applies the provided <paramref name="updateEvent"/> in the provided <paramref name="nomadFolder"/>.
-    /// </summary>
-    /// <param name="nomadFolder">The folder to operate in.</param>
-    /// <param name="updateEvent">The event content to apply without side effects.</param>
-    /// <param name="cancellationToken">A token that can be used to cancel the ongoing task.</param>
-    public static Task<NomadStorableData?> ApplyFolderUpdateAsync(this IReadOnlyKuboBasedNomadFolder nomadFolder, CreateFolderInFolderEvent updateEvent, CancellationToken cancellationToken)
-    {
-        cancellationToken.ThrowIfCancellationRequested();
-
-        // Apply folder updates
-        var existing = nomadFolder.Inner.Folders.FirstOrDefault(x =>
-            x.StorableItemId == updateEvent.StorableItemId ||
-            x.StorableItemName == updateEvent.StorableItemName);
-
-        if (updateEvent.Overwrite)
-        {
-            nomadFolder.Inner.Folders.Remove(existing);
-            existing = null;
-        }
-
-        var nomadFolderData = existing ?? new NomadFolderData<Cid>
-        {
-            StorableItemName = updateEvent.StorableItemName,
-            StorableItemId = updateEvent.StorableItemId,
-            Sources = nomadFolder.Sources,
-            Files = [],
-            Folders = [],
-        };
-        
-        if (nomadFolder.Inner.Folders.All(x => x.StorableItemId != nomadFolderData.StorableItemId))
-            nomadFolder.Inner.Folders.Add(nomadFolderData);
-        
-        return Task.FromResult<NomadStorableData?>(nomadFolderData);
     }
 
     /// <summary>
@@ -184,9 +115,9 @@ public static class KuboBasedNomadStorageExtensions
     }
 
     /// <summary>
-    /// A lock for <see cref="AppendAndPublishNewEntryToEventStreamAsync{T}"/>.
+    /// A lock for <see cref="AppendEventStreamEntryAsync{T}"/>.
     /// </summary>
-    private static SemaphoreSlim AppendAndPublishLock { get; } = new(1, 1);
+    private static SemaphoreSlim AppendLock { get; } = new(1, 1);
 
     /// <summary>
     /// Appends a new event to the event stream and publishes it to ipns.
@@ -197,20 +128,14 @@ public static class KuboBasedNomadStorageExtensions
     /// <param name="targetId">A unique identifier for the provided <paramref name="handler"/> that can be used to reapply the event later.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <returns>A task containing the new event stream entry.</returns>
-    public static async Task<EventStreamEntry<Cid>> AppendAndPublishNewEntryToEventStreamAsync<T>(this IModifiableNomadKuboEventStreamHandler<T> handler, Cid updateEventContentCid, string eventId, string targetId, CancellationToken cancellationToken)
+    public static async Task<EventStreamEntry<Cid>> AppendEventStreamEntryAsync<T>(this INomadKuboEventStreamHandler<T> handler, Cid updateEventContentCid, string eventId, string targetId, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         var client = handler.Client;
 
-        using (await AppendAndPublishLock.DisposableWaitAsync(cancellationToken: cancellationToken))
+        using (await AppendLock.DisposableWaitAsync(cancellationToken: cancellationToken))
         {
             // Get local event stream.
-            var keys = await client.Key.ListAsync(cancellationToken);
-
-            var nomadLocalSourceKey = keys.First(x => x.Name == handler.LocalEventStreamKeyName);
-            var (localEventStreamContent, _) = await nomadLocalSourceKey.Id.ResolveDagCidAsync<EventStream<Cid>>(client, nocache: !handler.KuboOptions.UseCache, cancellationToken);
-            Guard.IsNotNull(localEventStreamContent);
-            
             cancellationToken.ThrowIfCancellationRequested();
 
             // Append the event to the local event stream.
@@ -226,21 +151,9 @@ public static class KuboBasedNomadStorageExtensions
             var newEventStreamEntryCid = await client.Dag.PutAsync(newEventStreamEntry, pin: handler.KuboOptions.ShouldPin, cancel: cancellationToken);
 
             // Add new entry cid to event stream content.
-            localEventStreamContent.Entries.Add(newEventStreamEntryCid);
+            handler.LocalEventStream.Entries.Add(newEventStreamEntryCid);
+            handler.AllEventStreamEntries.Add(newEventStreamEntry);
             
-            Logger.LogInformation($"{nameof(localEventStreamContent)} entries for {localEventStreamContent.TargetId}:");
-            foreach(var entry in localEventStreamContent.Entries)
-                Logger.LogInformation($"{nameof(localEventStreamContent)} {localEventStreamContent.TargetId}: {entry}");
-            
-
-            // Get new cid for full local event stream.
-            var localEventStreamCid = await client.Dag.PutAsync(localEventStreamContent, pin: handler.KuboOptions.ShouldPin, cancel: cancellationToken);
-
-            // Update the local event stream in ipns.
-            Guard.IsNotEqualTo(handler.LocalEventStreamKeyName, handler.RoamingKeyName);
-            Guard.IsNotNullOrWhiteSpace(handler.LocalEventStreamKeyName);
-            await client.Name.PublishAsync(localEventStreamCid, handler.LocalEventStreamKeyName, cancel: cancellationToken);
-
             return newEventStreamEntry;
         }
     }

--- a/src/Extensions/KuboBasedNomadStorageExtensions.cs
+++ b/src/Extensions/KuboBasedNomadStorageExtensions.cs
@@ -4,6 +4,7 @@ using System.Threading;
 using System.Threading.Tasks;
 using CommunityToolkit.Diagnostics;
 using Ipfs;
+using OwlCore.Diagnostics;
 using OwlCore.Extensions;
 using OwlCore.Kubo;
 using OwlCore.Nomad.Kubo;
@@ -227,16 +228,17 @@ public static class KuboBasedNomadStorageExtensions
             // Add new entry cid to event stream content.
             localEventStreamContent.Entries.Add(newEventStreamEntryCid);
             
-            /*
             Logger.LogInformation($"{nameof(localEventStreamContent)} entries for {localEventStreamContent.TargetId}:");
             foreach(var entry in localEventStreamContent.Entries)
-            Logger.LogInformation($"{nameof(localEventStreamContent)} {localEventStreamContent.TargetId}: {entry}");
-            */
+                Logger.LogInformation($"{nameof(localEventStreamContent)} {localEventStreamContent.TargetId}: {entry}");
+            
 
             // Get new cid for full local event stream.
             var localEventStreamCid = await client.Dag.PutAsync(localEventStreamContent, pin: handler.KuboOptions.ShouldPin, cancel: cancellationToken);
 
             // Update the local event stream in ipns.
+            Guard.IsNotEqualTo(handler.LocalEventStreamKeyName, handler.RoamingKeyName);
+            Guard.IsNotNullOrWhiteSpace(handler.LocalEventStreamKeyName);
             await client.Name.PublishAsync(localEventStreamCid, handler.LocalEventStreamKeyName, cancel: cancellationToken);
 
             return newEventStreamEntry;

--- a/src/IModifiableKuboNomadFile.cs
+++ b/src/IModifiableKuboNomadFile.cs
@@ -1,11 +1,12 @@
 ﻿using OwlCore.Nomad.Kubo;
 using OwlCore.Nomad.Storage.Kubo.Models;
+using OwlCore.Storage;
 
 namespace OwlCore.Nomad.Storage.Kubo;
 
 /// <summary>
 /// A modifiable kubo-based storage interface for files.
 /// </summary>
-public interface IModifiableKuboBasedNomadFile : IReadOnlyKuboBasedNomadFile, IModifiableNomadKuboEventStreamHandler<FileUpdateEvent>
+public interface IModifiableKuboNomadFile : INomadKuboEventStreamHandler<FileUpdateEvent>, IReadOnlyKuboNomadFile
 {
 }

--- a/src/IModifiableKuboNomadFolder.cs
+++ b/src/IModifiableKuboNomadFolder.cs
@@ -1,11 +1,12 @@
 ﻿using OwlCore.Nomad.Kubo;
 using OwlCore.Nomad.Storage.Models;
+using OwlCore.Storage;
 
 namespace OwlCore.Nomad.Storage.Kubo;
 
 /// <summary>
 /// A modifiable kubo-based storage interface for folders.
 /// </summary>
-public interface IModifiableKuboBasedNomadFolder : IReadOnlyKuboBasedNomadFolder, IModifiableNomadKuboEventStreamHandler<FolderUpdateEvent>
+public interface IModifiableKuboNomadFolder : IReadOnlyKuboBasedNomadFolder, INomadKuboEventStreamHandler<FolderUpdateEvent>, IModifiableFolder
 {
 }

--- a/src/IReadOnlyKuboBasedNomadFolder.cs
+++ b/src/IReadOnlyKuboBasedNomadFolder.cs
@@ -12,6 +12,6 @@ namespace OwlCore.Nomad.Storage.Kubo;
 /// <remarks>
 /// Primarily use to create extension method helpers between file/folder implementations of the generic base classes.
 /// </remarks>
-public interface IReadOnlyKuboBasedNomadFolder : IReadOnlyNomadKuboEventStreamHandler<FolderUpdateEvent>, IChildFolder, IMutableFolder, IDelegable<NomadFolderData<Cid>>
+public interface IReadOnlyKuboBasedNomadFolder : IChildFolder, IMutableFolder, IDelegable<NomadFolderData<Cid>>
 {
 }

--- a/src/IReadOnlyKuboNomadFile.cs
+++ b/src/IReadOnlyKuboNomadFile.cs
@@ -10,6 +10,6 @@ namespace OwlCore.Nomad.Storage.Kubo;
 /// <summary>
 /// A kubo-based storage interface for files.
 /// </summary>
-public interface IReadOnlyKuboBasedNomadFile : IReadOnlyNomadKuboEventStreamHandler<FileUpdateEvent>, IChildFile, IDelegable<NomadFileData<Cid>>
+public interface IReadOnlyKuboNomadFile : IChildFile, IDelegable<NomadFileData<Cid>>
 {
 }

--- a/src/KuboNomadFolder.cs
+++ b/src/KuboNomadFolder.cs
@@ -233,7 +233,10 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
 
         // Add local event stream source, if exists and needed
         Logger.LogInformation($"Loading local event stream");
-        var localKey = await client.GetOrCreateKeyAsync(localEventStreamKeyName, _ => new EventStream<Cid> { TargetId = roamingIpnsKey, Label = string.Empty, Entries = [] }, kuboOptions.IpnsLifetime, 4096, cancellationToken);
+        var localKey = enumerable.FirstOrDefault(x => x.Id == roamingIpnsKey);
+        if (localKey is null)
+            throw new ArgumentException($"Tried to create modifiable folder, but roaming key {roamingIpnsKey} hasn't been imported and can't be written to.");
+        
         var (localEventStream, _) = await client.ResolveDagCidAsync<EventStream<Cid>>(localKey.Id, nocache: !kuboOptions.UseCache, cancellationToken);
         Guard.IsNotNull(localEventStream);
 

--- a/src/KuboNomadFolder.cs
+++ b/src/KuboNomadFolder.cs
@@ -7,8 +7,6 @@ using CommunityToolkit.Diagnostics;
 using Ipfs;
 using Ipfs.CoreApi;
 using OwlCore.ComponentModel;
-using OwlCore.Diagnostics;
-using OwlCore.Kubo;
 using OwlCore.Nomad.Kubo;
 using OwlCore.Nomad.Storage.Kubo.Extensions;
 using OwlCore.Nomad.Storage.Models;
@@ -17,9 +15,9 @@ using OwlCore.Storage;
 namespace OwlCore.Nomad.Storage.Kubo;
 
 /// <summary>
-/// A virtual file constructed by advancing an <see cref="IEventStreamHandler{TEventStreamEntry}.EventStreamPosition"/> using multiple <see cref="ISources{T}.Sources"/> in concert with other <see cref="ISharedEventStreamHandler{TContentPointer, TEventStreamSource, TEventStreamEntry, TListeningHandlers}.ListeningEventStreamHandlers"/>.
+/// A virtual file constructed by advancing an <see cref="IEventStreamHandler{TContentPointer, TEventStream, TEventStreamEntry}.EventStreamPosition"/> using multiple <see cref="ISources{T}.Sources"/> in concert with other <see cref="ISharedEventStreamHandler{TContentPointer, TEventStreamSource, TEventStreamEntry, TListeningHandlers}.ListeningEventStreamHandlers"/>.
 /// </summary>
-public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEntry<Cid>>, IModifiableKuboBasedNomadFolder, IFlushable, ICreateCopyOf
+public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEntry<Cid>>, IModifiableKuboNomadFolder
 {
     /// <summary>
     /// Creates a new instance of <see cref="KuboNomadFolder"/>.
@@ -37,86 +35,27 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
     public required ICoreApi Client { get; set; }
 
     /// <inheritdoc />
-    public required string LocalEventStreamKeyName { get; init; }
+    public required IKey LocalEventStreamKey { get; init; }
 
     /// <inheritdoc />
-    public required string RoamingKeyName { get; init; }
-
-    /// <summary>
-    /// The resolved event stream entries to use when constructing child files and folders.
-    /// </summary>
-    public ICollection<EventStreamEntry<Cid>> EventStreamEntries { get; init; } = [];
+    public required IKey RoamingKey { get; init; }
 
     /// <summary>
     /// The interval that IPNS should be checked for updates.
     /// </summary>
     public TimeSpan UpdateCheckInterval { get; } = TimeSpan.FromMinutes(1);
 
-    /// <inheritdoc/>
-    public override async Task DeleteAsync(IStorableChild item, CancellationToken cancellationToken = default)
-    {
-        var storageUpdateEvent = new DeleteFromFolderEvent(Id, item.Id, item.Name);
-        await ApplyEntryUpdateAsync(storageUpdateEvent, cancellationToken);
-        EventStreamPosition = await AppendNewEntryAsync(storageUpdateEvent, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public override async Task<IChildFolder> CreateFolderAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
-    {
-        var storageUpdateEvent = new CreateFolderInFolderEvent(Id, $"{Id}/{name}", name, overwrite);
-        var createdFolderData = (NomadFolderData<Cid>?)await this.ApplyFolderUpdateAsync(storageUpdateEvent, cancellationToken);
-        EventStreamPosition = await AppendNewEntryAsync(storageUpdateEvent, cancellationToken);
-
-        Guard.IsNotNull(createdFolderData);
-        return await FolderDataToInstanceAsync(createdFolderData, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public override async Task<IChildFile> CreateFileAsync(string name, bool overwrite = false, CancellationToken cancellationToken = default)
-    {
-        var storageUpdateEvent = new CreateFileInFolderEvent(Id, $"{Id}/{name}", name, overwrite);
-        var createdFileData = (NomadFileData<Cid>?)await this.ApplyFolderUpdateAsync(storageUpdateEvent, cancellationToken);
-        EventStreamPosition = await AppendNewEntryAsync(storageUpdateEvent, cancellationToken);
-
-        Guard.IsNotNull(createdFileData);
-        return await FileDataToInstanceAsync(createdFileData, cancellationToken);
-    }
-
-    /// <inheritdoc/>
-    public async Task<IChildFile> CreateCopyOfAsync(IFile fileToCopy, bool overwrite, CancellationToken cancellationToken, CreateCopyOfDelegate fallback)
-    {
-        var existing = Inner.Files.FirstOrDefault(x => x.StorableItemName == fileToCopy.Name);
-        if (overwrite && existing is not null)
-        {
-            // Delete before creating.
-            var storageUpdateEvent = new DeleteFromFolderEvent(Id, existing.StorableItemId, existing.StorableItemName);
-            await ApplyEntryUpdateAsync(storageUpdateEvent, cancellationToken);
-            EventStreamPosition = await AppendNewEntryAsync(storageUpdateEvent, cancellationToken);
-        }
-        
-        var destinationFile = await CreateFileAsync(fileToCopy.Name, overwrite, cancellationToken);
-        var destinationStream = await destinationFile.OpenWriteAsync(cancellationToken);
-        var sourceStream = await fileToCopy.OpenReadAsync(cancellationToken);
-
-        await sourceStream.CopyToAsync(destinationStream, 81920, cancellationToken);
-        destinationStream.Dispose();
-        sourceStream.Dispose();
-        
-        return destinationFile;
-    }
-
-    /// <inheritdoc/>
+    /// <inheritdoc cref="INomadKuboEventStreamHandler{TEventEntryContent}.AppendNewEntryAsync" />
     public override async Task<EventStreamEntry<Cid>> AppendNewEntryAsync(FolderUpdateEvent updateEvent, CancellationToken cancellationToken = default)
     {
         // Use extension method for code deduplication (can't use inheritance).
         var localUpdateEventCid = await Client.Dag.PutAsync(updateEvent, pin: KuboOptions.ShouldPin, cancel: cancellationToken);
-        var newEntry = await this.AppendAndPublishNewEntryToEventStreamAsync(localUpdateEventCid, updateEvent.EventId, targetId: Id, cancellationToken);
-        EventStreamEntries.Add(newEntry);
+        var newEntry = await this.AppendEventStreamEntryAsync(localUpdateEventCid, updateEvent.EventId, targetId: Id, cancellationToken);
         return newEntry;
     }
 
-    /// <inheritdoc/>
-    public Task ApplyEntryUpdateAsync(FolderUpdateEvent updateEventContent, CancellationToken cancellationToken)
+    /// <inheritdoc cref="NomadFolder{TContentPointer,TEventStreamSource,TEventStreamEntry}.ApplyEntryUpdateAsync" />
+    public override Task ApplyEntryUpdateAsync(FolderUpdateEvent updateEventContent, CancellationToken cancellationToken)
     {
         // Use extension methods for code deduplication (can't use inheritance).
         return updateEventContent switch
@@ -131,7 +70,6 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
     /// <inheritdoc />
     public override Task AdvanceEventStreamAsync(EventStreamEntry<Cid> streamEntry, CancellationToken cancellationToken)
     {
-        // Use extension method for code deduplication (can't use inheritance).
         return this.TryAdvanceEventStreamAsync(streamEntry, cancellationToken);
     }
 
@@ -139,7 +77,7 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
     public override Task<IFolderWatcher> GetFolderWatcherAsync(CancellationToken cancellationToken = default) => Task.FromResult<IFolderWatcher>(new TimerBasedNomadFolderWatcher(this, UpdateCheckInterval));
 
     /// <inheritdoc />
-    protected override async Task<ReadOnlyNomadFile<Cid, EventStream<Cid>, EventStreamEntry<Cid>>> FileDataToInstanceAsync(NomadFileData<Cid> fileData, CancellationToken cancellationToken)
+    protected override async Task<NomadFile<Cid, EventStream<Cid>, EventStreamEntry<Cid>>> FileDataToInstanceAsync(NomadFileData<Cid> fileData, CancellationToken cancellationToken)
     {
         var file = new KuboNomadFile(ListeningEventStreamHandlers)
         {
@@ -148,10 +86,11 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
             Parent = this,
             Sources = Sources,
             Inner = fileData,
-            LocalEventStreamKeyName = LocalEventStreamKeyName,
-            RoamingKeyName = RoamingKeyName,
-            EventStreamId = EventStreamId,
-            EventStreamEntries = EventStreamEntries,
+            LocalEventStreamKey = LocalEventStreamKey,
+            RoamingKey = RoamingKey,
+            EventStreamHandlerId = EventStreamHandlerId,
+            AllEventStreamEntries = AllEventStreamEntries,
+            LocalEventStream = LocalEventStream,
         };
         
         Guard.IsNotNull(EventStreamPosition?.TimestampUtc);
@@ -159,14 +98,14 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
         // Modifiable data cannot read remote changes from the roaming snapshot.
         // Event stream must be advanced using known sources.
         // Resolved event stream entries are passed down the same as sources are.
-        foreach (var entry in EventStreamEntries.ToArray().OrderBy(x => x.TimestampUtc).Where(x=> x.TargetId == file.Id))
+        foreach (var entry in AllEventStreamEntries.ToArray().OrderBy(x => x.TimestampUtc).Where(x=> x.TargetId == file.Id))
             await file.AdvanceEventStreamAsync(entry, cancellationToken);
 
         return file;
     }
 
     /// <inheritdoc />
-    protected override async Task<ReadOnlyNomadFolder<Cid, EventStream<Cid>, EventStreamEntry<Cid>>> FolderDataToInstanceAsync(NomadFolderData<Cid> folderData, CancellationToken cancellationToken)
+    protected override async Task<NomadFolder<Cid, EventStream<Cid>, EventStreamEntry<Cid>>> FolderDataToInstanceAsync(NomadFolderData<Cid> folderData, CancellationToken cancellationToken)
     {
         var folder = new KuboNomadFolder(ListeningEventStreamHandlers)
         {
@@ -175,10 +114,11 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
             Parent = this,
             Sources = Sources,
             Inner = folderData,
-            LocalEventStreamKeyName = LocalEventStreamKeyName,
-            RoamingKeyName = RoamingKeyName,
-            EventStreamEntries = EventStreamEntries,
-            EventStreamId = EventStreamId,
+            LocalEventStreamKey = LocalEventStreamKey,
+            RoamingKey = RoamingKey,
+            AllEventStreamEntries = AllEventStreamEntries,
+            EventStreamHandlerId = EventStreamHandlerId,
+            LocalEventStream = LocalEventStream,
         };
         
         Guard.IsNotNull(EventStreamPosition?.TimestampUtc);
@@ -186,93 +126,9 @@ public class KuboNomadFolder : NomadFolder<Cid, EventStream<Cid>, EventStreamEnt
         // Modifiable data cannot read remote changes from the roaming snapshot.
         // Event stream must be advanced using known sources.
         // Resolved event stream entries are passed down the same as sources are.
-        foreach (var entry in EventStreamEntries.ToArray().OrderBy(x => x.TimestampUtc).Where(x=> x.TargetId == folder.Id))
+        foreach (var entry in AllEventStreamEntries.ToArray().OrderBy(x => x.TimestampUtc).Where(x=> x.TargetId == folder.Id))
             await folder.AdvanceEventStreamAsync(entry, cancellationToken);
 
         return folder;
-    }
-
-    /// <summary>
-    /// Creates a new instance of <see cref="KuboNomadFolder"/> using the given parameters.
-    /// </summary>
-    /// <param name="roamingIpnsKey">The roaming ipns key to publish the final state to.</param>
-    /// <param name="localEventStreamKeyName">The name of the local event stream to publish modifications to.</param>
-    /// <param name="client">The client to use for communicating with ipfs.</param>
-    /// <param name="kuboOptions">The options to use when publishing data to Kubo.</param>
-    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    /// <returns>A task with the requested folder as the result.</returns>
-    /// <exception cref="ArgumentException">The provided <paramref name="roamingIpnsKey"/> isn't imported on the local machine, so the folder can't be modified.</exception>
-    public static async Task<KuboNomadFolder> CreateAsync(Cid roamingIpnsKey, string localEventStreamKeyName, ICoreApi client, IKuboOptions kuboOptions, CancellationToken cancellationToken)
-    {
-        var sharedEventStreamHandlers = new List<ISharedEventStreamHandler<Cid, EventStream<Cid>, EventStreamEntry<Cid>>>();
-        var keys = await client.Key.ListAsync(cancellationToken);
-
-        // Roaming keys are published from multiple nodes.
-        // If we're publishing this roaming key, we cannot read the latest published by another node, we must build from sources.
-        var enumerable = keys as IKey[] ?? keys.ToArray();
-        var importedRoamingKey = enumerable.FirstOrDefault(x => x.Id == roamingIpnsKey);
-        if (importedRoamingKey is null)
-            throw new ArgumentException($"Tried to create modifiable folder, but roaming key {roamingIpnsKey} hasn't been imported and can't be written to.");
-
-        // Add published event stream sources, if any
-        Logger.LogInformation($"Loading sources from roaming key {roamingIpnsKey}");
-        var (publishedData, _) = await roamingIpnsKey.ResolveDagCidAsync<NomadFolderData<Cid>>(client, nocache: !kuboOptions.UseCache, cancellationToken);
-        Guard.IsNotNull(publishedData);
-
-        var folder = new KuboNomadFolder(sharedEventStreamHandlers)
-        {
-            EventStreamId = roamingIpnsKey,
-            LocalEventStreamKeyName = localEventStreamKeyName,
-            RoamingKeyName = importedRoamingKey.Name,
-            Sources = publishedData.Sources,
-            Inner = publishedData,
-            Client = client,
-            KuboOptions = kuboOptions,
-            Parent = null,
-        };
-
-        // Add local event stream source, if exists and needed
-        Logger.LogInformation($"Loading local event stream");
-        var localKey = enumerable.FirstOrDefault(x => x.Id == roamingIpnsKey);
-        if (localKey is null)
-            throw new ArgumentException($"Tried to create modifiable folder, but roaming key {roamingIpnsKey} hasn't been imported and can't be written to.");
-        
-        var (localEventStream, _) = await client.ResolveDagCidAsync<EventStream<Cid>>(localKey.Id, nocache: !kuboOptions.UseCache, cancellationToken);
-        Guard.IsNotNull(localEventStream);
-
-        var roamingKeyMatchesLocalEventStream = localEventStream.TargetId == roamingIpnsKey;
-        if (roamingKeyMatchesLocalEventStream)
-        {
-            var sourceNotAdded = folder.Sources.All(x => x != localKey.Id);
-            if (sourceNotAdded)
-            {
-                Logger.LogInformation($"Adding local key {localKey.Id} to sources");
-                folder.Sources.Add(localKey.Id);
-            }
-            else
-            {
-                Logger.LogInformation($"Local source {localKey.Id} already present in sources");
-            }
-        }
-        
-        Logger.LogInformation($"Using {folder.Sources.Count} event stream sources:");
-        foreach (var source in folder.Sources)
-            Logger.LogInformation(source);
-
-        return folder;
-    }
-
-    /// <summary>
-    /// Flushes changes to the <see cref="RoamingKeyName"/> and <see cref="LocalEventStreamKeyName"/>.
-    /// </summary>
-    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
-    public virtual async Task FlushAsync(CancellationToken cancellationToken)
-    {
-        // TODO: Optional. Create a read-only version and recursively copy to mfs, then publish the resulting unixfs cid.
-        var root = (KuboNomadFolder?)await GetRootAsync(cancellationToken);
-        if (root is null)
-            root = this;
-        
-        await root.PublishRoamingAsync<KuboNomadFolder, FolderUpdateEvent, NomadFolderData<Cid>>(cancellationToken);
     }
 }

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -24,6 +24,8 @@
 --- 0.8.0 ---
 [Breaking]
 Inherited and implemented breaking changes from OwlCore.Nomad 0.8.0.
+Inherited and implemented breaking changes from OwlCore.Nomad.Storage 0.8.0.
+Inherited and implemented breaking changes from OwlCore.Nomad.Kubo 0.9.0.
 KuboBasedNomadStorageExtensions.TryAdvanceEventStream now takes IModifiableKuboNomadFile or IModifiableKuboNomadFolder as the 'this' param.
 KuboNomadFolder still uses the event stream handler from OwlCore.Noamd.Storage.NomadFolder, but ReadOnlyKuboNomadFolder uses roaming data directly and does not use an event stream handler. 
 KuboBasedNomadStorageExtensions.ApplyFolderUpdateAsync and KuboBasedNomadStorageExtensions.ApplyFileUpdateAsync were removed as they are now handled by the underlying NomadFolder implementation.
@@ -159,7 +161,7 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="OwlCore.Kubo" Version="0.17.2" />
 		<PackageReference Include="OwlCore.Nomad.Storage" Version="0.8.0" />
-		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.8.0" />
+		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.9.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -145,7 +145,6 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="OwlCore.Kubo" Version="0.17.1" />
 		<PackageReference Include="OwlCore.Nomad.Storage" Version="0.7.0" />
-		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.8.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -158,5 +157,9 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\ocnomadkubo\src\OwlCore.Nomad.Kubo.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -14,13 +14,27 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.7.0</Version>
+		<Version>0.8.0</Version>
 		<Product>OwlCore</Product>
 		<Description>A storage implementation powered by shared event sourcing on IPFS.</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Storage.Kubo</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.8.0 ---
+[Breaking]
+Inherited and implemented breaking changes from OwlCore.Nomad 0.8.0.
+KuboBasedNomadStorageExtensions.TryAdvanceEventStream now takes IModifiableKuboNomadFile or IModifiableKuboNomadFolder as the 'this' param.
+KuboNomadFolder still uses the event stream handler from OwlCore.Noamd.Storage.NomadFolder, but ReadOnlyKuboNomadFolder uses roaming data directly and does not use an event stream handler. 
+KuboBasedNomadStorageExtensions.ApplyFolderUpdateAsync and KuboBasedNomadStorageExtensions.ApplyFileUpdateAsync were removed as they are now handled by the underlying NomadFolder implementation.
+
+[Fixes]
+Fixed an issue with WritableNomadFileStream where a race condition + bad stream seeking would cause empty content to be flushed to Kubo.
+
+[Improvements]
+Ported and refined prototype CLI code to build out a test suite for this implementation, which helped clear up most of the remaining inconsistencies around Nomad as a whole.
+Generally, the library no longer auto-publishes to Kubo for you, instead holding the data in memory and sharing across instances. The constructor caller is expected to know when and why to flush roaming or local data to Kubo. 
+
 --- 0.7.0 ---
 [Fixes]
 Fixed an issue where calling AppendAndPublishNewEntryToEventStreamAsync with concurrency could have caused data to be lost.
@@ -143,8 +157,9 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-		<PackageReference Include="OwlCore.Kubo" Version="0.17.1" />
-		<PackageReference Include="OwlCore.Nomad.Storage" Version="0.7.0" />
+		<PackageReference Include="OwlCore.Kubo" Version="0.17.2" />
+		<PackageReference Include="OwlCore.Nomad.Storage" Version="0.8.0" />
+		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.8.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -157,9 +172,5 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\..\ocnomadkubo\src\OwlCore.Nomad.Kubo.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/WritableNomadFileStream.cs
+++ b/src/WritableNomadFileStream.cs
@@ -45,12 +45,19 @@ public class WritableNomadFileStream : WritableLazySeekStream
         if (Position != Length)
             Seek(0, SeekOrigin.End);
 
+        if (DestinationStream.Position != 0)
+            DestinationStream.Position = 0;
+
+        if (MemoryStream.Position != 0)
+            MemoryStream.Position = 0;
+        
+        Guard.IsGreaterThan(MemoryStream.Length, 0);
+
         // Copy memory stream to destination.
         // Will include any writes done below.
         await MemoryStream.CopyToAsync(DestinationStream);
-
-        if (DestinationStream.Position != 0)
-            DestinationStream.Position = 0;
+        
+        Guard.IsGreaterThan(DestinationStream.Length, 0);
 
         // Calculate hash first
         var addFileOptions = new AddFileOptions { Pin = false, OnlyHash = true };

--- a/tests/Extensions/RecursiveCopyFolderExtensions.cs
+++ b/tests/Extensions/RecursiveCopyFolderExtensions.cs
@@ -1,0 +1,191 @@
+﻿using System.Text;
+using OwlCore.Diagnostics;
+using OwlCore.Extensions;
+using OwlCore.Storage;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests.Extensions;
+
+/// <summary>
+/// Extension methods and helpers for storage.
+/// </summary>
+public static partial class StorageExtensions
+{
+    /// <summary>
+    /// Recursively sync the items in a source folder to a destination folder, taking last update time into account, avoiding overwrite when the destination is newer and <paramref name="getLastUpdateTime"/> is defined.
+    /// </summary>
+    /// <param name="sourceFolder">The source folder to recursively crawl and copy.</param>
+    /// <param name="destinationFolder">The folder to copy contents to.</param>
+    /// <param name="getLastUpdateTime">A callback to provide the last update time for a given <see cref="IStorable"/>.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    /// <exception cref="ArgumentException">Source folder yielded a child item that isn't a file or folder.</exception>
+    public static async Task CopyToAsync(this IFolder sourceFolder, IModifiableFolder destinationFolder, Func<IStorable, DateTime>? getLastUpdateTime = null, CancellationToken cancellationToken = default, IChildFile? gitignoreFile = null)
+    {
+        // Create a dictionary of destination items.
+        // Items are gradually removed as source items are copied to destination.
+        // Whatever is left in this dictionary is a list of items not present in the source folder.
+        var destinationItemsByName = await destinationFolder.GetItemsAsync(StorableType.All, cancellationToken).ToDictionaryAsync(item => item.Name, item => item, cancellationToken);
+
+        var gitignore = new Ignore.Ignore();
+        IFolder? gitignoreFolder = null;
+
+        try
+        {
+            // Inherit gitignore from parent, or open in current folder if exists
+            gitignoreFile ??= (IChildFile)await sourceFolder.GetFirstByNameAsync(".gitignore", cancellationToken);
+
+            await using var stream = await gitignoreFile.OpenStreamAsync(FileAccess.Read, cancellationToken);
+            var bytes = await stream.ToBytesAsync(cancellationToken: cancellationToken);
+
+            gitignore.Add(Encoding.UTF8.GetString(bytes).Split(Environment.NewLine.ToCharArray()));
+
+            // Get containing folder
+            gitignoreFolder = await gitignoreFile.GetParentAsync(cancellationToken);
+        }
+        catch (FileNotFoundException)
+        {
+        }
+
+        // Sync from source to destination.
+        await foreach (var sourceItem in sourceFolder.GetItemsAsync(StorableType.All, cancellationToken))
+        {
+            if (cancellationToken.IsCancellationRequested)
+                cancellationToken.ThrowIfCancellationRequested();
+
+            // File exists in source and needs copied to destination, unmark for deletion on destination
+            destinationItemsByName.Remove(sourceItem.Name);
+
+            // If gitignore is present
+            if (gitignoreFolder is not null)
+            {
+                // Get relative path from git root to item being copied
+                var relativePathFromGitignore = await gitignoreFolder.GetRelativePathToAsync(sourceItem, cancellationToken: cancellationToken);
+
+                var isExcludedByGitignore = gitignore.IsIgnored(relativePathFromGitignore);
+                if (isExcludedByGitignore)
+                {
+                    Logger.LogInformation($"Skipped via gitignore: {relativePathFromGitignore}");
+                    continue;
+                }
+            }
+
+            // Process as folder
+            if (sourceItem is IFolder sourceSubFolder)
+            {
+                // Create or get existing subfolder in the destination and recursively synchronize.
+                var destinationSubFolder = (IModifiableFolder)await destinationFolder.CreateFolderAsync(sourceSubFolder.Name, overwrite: false, cancellationToken);
+
+                await sourceSubFolder.CopyToAsync(destinationSubFolder, getLastUpdateTime, cancellationToken, gitignoreFile);
+                continue;
+            }
+
+            // Process as file (for the rest of this method)
+            if (sourceItem is not IFile sourceFile)
+                continue;
+
+            IFile? existingDestinationFile = null;
+            bool sourceIsNewerOrSame = false;
+            try
+            {
+                // Get destination storable for lastModified comparison
+                existingDestinationFile = (IFile)await destinationFolder.GetFirstByNameAsync(sourceFile.Name, cancellationToken);
+
+                // Compare the last modified dates
+                var destinationLastModified = getLastUpdateTime?.Invoke(existingDestinationFile);
+                var sourceLastModified = getLastUpdateTime?.Invoke(sourceFile);
+
+                sourceIsNewerOrSame = sourceLastModified >= destinationLastModified;
+            }
+            catch (FileNotFoundException)
+            {
+                // ignored, create file instead.
+                // overwrite value no longer matters (file does not exist).
+            }
+
+            // If destination file already exists
+            if (existingDestinationFile is not null)
+            {
+                // and the source is older than the destination
+                if (!sourceIsNewerOrSame)
+                {
+                    // we should not copy it
+                    Logger.LogInformation($"Up to date {existingDestinationFile.Id}");
+                    continue;
+                }
+            }
+
+            Logger.LogInformation($"Copying {sourceFile.Name} to {destinationFolder.Id}");
+            await destinationFolder.CreateCopyOfAsync(sourceFile, overwrite: true, cancellationToken);
+        }
+
+        // Any remaining items are present in the destination folder but not in the source folder and should be deleted.
+        foreach (var destinationItem in destinationItemsByName.Values)
+        {
+            if (cancellationToken.IsCancellationRequested)
+                cancellationToken.ThrowIfCancellationRequested();
+
+            await destinationFolder.DeleteAsync(destinationItem, cancellationToken);
+            Logger.LogInformation($"Cleanup deleted file {destinationItem.Id}");
+        }
+    }
+
+    /// <summary>
+    /// From the provided <see cref="IStorable"/>, traverses the provided relative path and returns the item at that path.
+    /// </summary>
+    /// <param name="from">The item to start with when traversing.</param>
+    /// <param name="relativePath">The path of the storable item to return, relative to the provided item.</param>
+    /// <param name="cancellationToken">A token to cancel the ongoing operation.</param>
+    /// <returns>The <see cref="IStorable"/> item found at the relative path.</returns>
+    /// <exception cref="ArgumentException">
+    /// A parent directory was specified, but the provided <see cref="IStorable"/> is not addressable.
+    /// Or, the provided relative path named a folder, but the item was a file.
+    /// Or, an empty path part was found.
+    /// </exception>
+    /// <exception cref="ArgumentOutOfRangeException">A parent folder was requested, but the storable item did not return a parent.</exception>
+    /// <exception cref="FileNotFoundException">A named item was specified in a folder, but the item wasn't found.</exception>
+    public static async Task<IStorable> GetOrCreateRelativePathAsync(this IStorable from, string relativePath, bool overwrite = false, CancellationToken cancellationToken = default)
+    {
+        var inputPathChars = new[] { Path.DirectorySeparatorChar, Path.AltDirectorySeparatorChar, Path.PathSeparator, Path.VolumeSeparatorChar };
+        var ourPathSeparator = @"/";
+
+        // Traverse only one level at a time
+        // But recursively, until the target has been reached.
+        var pathParts = relativePath.Split(inputPathChars).Where(x => !string.IsNullOrWhiteSpace(x) && x != ".").ToArray();
+
+        // Current directory was specified.
+        if (pathParts.Length == 0)
+            return from;
+
+        var nextPathPart = pathParts[0];
+        if (string.IsNullOrWhiteSpace(nextPathPart))
+            throw new ArgumentException("Empty path part found. Cannot navigate to an item without a name.", nameof(nextPathPart));
+
+        // Get parent directory.
+        if (nextPathPart == "..")
+        {
+            if (from is not IStorableChild child)
+                throw new ArgumentException($"A parent folder was requested, but the storable item named {from.Name} is not the child of a directory.", nameof(relativePath));
+
+            var parent = await child.GetParentAsync(cancellationToken);
+
+            // If this item was the last one needed.
+            if (parent is not null && pathParts.Length == 1)
+                return parent;
+
+            if (parent is null)
+                throw new ArgumentOutOfRangeException(nameof(relativePath), "A parent folder was requested, but the storable item did not return a parent.");
+
+            var newRelativePath = string.Join(ourPathSeparator, pathParts.Skip(1));
+            return await GetOrCreateRelativePathAsync(parent, newRelativePath);
+        }
+
+        // Create/Open item by name.
+        if (from is not IModifiableFolder folder)
+            throw new ArgumentException($"An item named {nextPathPart} was requested from the folder named {from.Name}, but {from.Name} is not a folder.");
+
+        var item = await folder.CreateFolderAsync(nextPathPart, overwrite, cancellationToken);
+        if (item is null)
+            throw new FileNotFoundException($"An item named {nextPathPart} was requested from the folder named {from.Name}, but {nextPathPart} wasn't found in the folder.");
+
+        return await GetOrCreateRelativePathAsync(item, string.Join(ourPathSeparator, pathParts.Skip(1)));
+    }
+}

--- a/tests/Extensions/StorageExtensions.cs
+++ b/tests/Extensions/StorageExtensions.cs
@@ -1,0 +1,22 @@
+﻿using System.Runtime.CompilerServices;
+using OwlCore.Storage;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests;
+
+public static class StorageExtensions
+{
+    public static async IAsyncEnumerable<IChildFile> CreateFilesAsync(this IModifiableFolder folder, int fileCount, Func<int, string> getFileName, [EnumeratorCancellation] CancellationToken cancellationToken)
+    {
+        for (var i = 0; i < fileCount; i++)
+            yield return await folder.CreateFileAsync(getFileName(i), overwrite: true, cancellationToken: cancellationToken);
+    }
+
+    public static async Task WriteRandomBytes(this IFile file, int numberOfBytes, CancellationToken cancellationToken)
+    {
+        var rnd = new Random();
+        var bytes = new byte[numberOfBytes];
+        rnd.NextBytes(bytes);
+        
+        await file.WriteBytesAsync(bytes, cancellationToken: cancellationToken);
+    }
+}

--- a/tests/KuboNomadFolderTests.Init.cs
+++ b/tests/KuboNomadFolderTests.Init.cs
@@ -1,0 +1,72 @@
+﻿using System.Diagnostics;
+using CommunityToolkit.Diagnostics;
+using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.Kubo;
+using OwlCore.Kubo.Cache;
+using OwlCore.Nomad.Kubo;
+using OwlCore.Nomad.Storage.Models;
+using OwlCore.Storage.System.IO;
+using OwlCore.Diagnostics;
+using OwlCore.Extensions;
+using OwlCore.Nomad.Kubo.Events;
+using OwlCore.Nomad.Storage.Kubo.Tests.Extensions;
+using OwlCore.Storage;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests;
+
+public partial class KuboNomadFolderTests
+{
+    [TestMethod]
+    public async Task InitTestAsync()
+    {
+        Logger.MessageReceived += LoggerOnMessageReceived;
+        var cancellationToken = CancellationToken.None;
+
+        var temp = new SystemFolder(Path.GetTempPath());
+        var testTempFolder = await SafeCreateFolderAsync(temp, $"{nameof(KuboNomadFolderTests)}.{nameof(InitTestAsync)}", cancellationToken);
+        var kubo = await BootstrapKuboAsync(testTempFolder, 5011, 8011, cancellationToken);
+        var kuboOptions = new KuboOptions
+        {
+            IpnsLifetime = TimeSpan.FromDays(1),
+            ShouldPin = false,
+            UseCache = true,
+        };
+        
+        var folderId = nameof(InitTestAsync);
+        var localKeyName = $"Nomad.Storage.Local.{folderId}";
+        var roamingKeyName = $"Nomad.Storage.Roaming.{folderId}";
+
+        var client = await CreateCachedClientAsync(kubo, cancellationToken);
+        var (local, roaming) = await CreateStorageKeysAsync(localKeyName, roamingKeyName, folderId, folderId, client, cancellationToken);
+        
+        // Roaming key should contain an empty list of files and folders, as well as the sources used to construct the object. 
+        Guard.IsNotNull(roaming.Key);
+        Guard.IsNotNullOrWhiteSpace(roaming.Key.Id);
+        {
+            Guard.IsNotNull(roaming.Value);
+            Guard.IsNotNullOrWhiteSpace(roaming.Value.StorableItemId);
+            Guard.IsNotNullOrWhiteSpace(roaming.Value.StorableItemName);
+            Guard.IsEmpty(roaming.Value.Files);
+            Guard.IsEmpty(roaming.Value.Folders);
+            Guard.IsNotEmpty(roaming.Value.Sources);
+        }
+        
+        // Local key should contain an empty event stream with the roaming key as the targetid
+        Guard.IsNotNull(local.Key);
+        Guard.IsNotNullOrWhiteSpace(local.Key.Id);
+        {
+            Guard.IsNotNull(local.Value);
+            Guard.IsNotNullOrWhiteSpace(local.Value.Label);
+            Guard.IsNotNullOrWhiteSpace(local.Value.TargetId);
+            Guard.IsEqualTo(local.Value.TargetId, $"{roaming.Key.Id}");
+            Guard.IsEmpty(local.Value.Entries.ToArray());
+        }
+
+        await kubo.Client.ShutdownAsync();
+        kubo.Dispose();
+        await SetAllFileAttributesRecursive(testTempFolder, attributes => attributes & ~FileAttributes.ReadOnly);
+        await temp.DeleteAsync(testTempFolder, cancellationToken);
+        Logger.MessageReceived -= LoggerOnMessageReceived;
+    }
+}

--- a/tests/KuboNomadFolderTests.Pair.cs
+++ b/tests/KuboNomadFolderTests.Pair.cs
@@ -1,0 +1,173 @@
+﻿using System.Diagnostics;
+using CommunityToolkit.Diagnostics;
+using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.Kubo;
+using OwlCore.Kubo.Cache;
+using OwlCore.Nomad.Kubo;
+using OwlCore.Nomad.Storage.Models;
+using OwlCore.Storage.System.IO;
+using OwlCore.Diagnostics;
+using OwlCore.Extensions;
+using OwlCore.Nomad.Kubo.Events;
+using OwlCore.Nomad.Storage.Kubo.Tests.Extensions;
+using OwlCore.Storage;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests;
+
+public partial class KuboNomadFolderTests
+{
+    [TestMethod]
+    public async Task PairingTestAsync()
+    {
+        Logger.MessageReceived += LoggerOnMessageReceived;
+        var cancellationToken = CancellationToken.None;
+
+        var temp = new SystemFolder(Path.GetTempPath());
+        var testTempFolder = await SafeCreateFolderAsync(temp, $"{nameof(KuboNomadFolderTests)}.{nameof(PairingTestAsync)}", cancellationToken);
+        var kuboOptions = new KuboOptions
+        {
+            IpnsLifetime = TimeSpan.FromDays(1),
+            ShouldPin = false,
+            UseCache = false,
+        };
+        
+        // Spawn kubo nodes
+        var nodeAFolder = (SystemFolder)await testTempFolder.CreateFolderAsync("node-a", overwrite: true, cancellationToken); 
+        var kuboA = await BootstrapKuboAsync(nodeAFolder, 5014, 8014, cancellationToken);
+        
+        var nodeBFolder = (SystemFolder)await testTempFolder.CreateFolderAsync("node-b", overwrite: true, cancellationToken);
+        var kuboB = await BootstrapKuboAsync(nodeBFolder, 5015, 8015, cancellationToken);
+        
+        // Connect kubo nodes in swarm
+        await AddPeerToSwarmAsync(kuboA.Client, kuboB.Client, cancellationToken);
+        await AddPeerToSwarmAsync(kuboB.Client, kuboA.Client, cancellationToken);
+
+        var clientA = kuboA.Client;
+        var clientB = kuboB.Client;
+        {
+            var folderId = nameof(PairingTestAsync);
+            var roamingKeyName = $"Nomad.Storage.Roaming.{folderId}";
+            var localKeyName = $"Nomad.Storage.Local.{folderId}";
+            
+            // Create local AND roaming keys for nodeA.
+            // During pairing, roamingA will be exported to nodeB, and localB will be added to the event stream for localA.
+            var (localA, roamingA) = await CreateStorageKeysAsync(localKeyName, roamingKeyName, folderId, folderId, clientA, cancellationToken);
+            {
+                // Default value validation.
+                // roaming should be the TargetId on local,
+                // local should be a source on roaming.
+                Guard.IsEqualTo(localA.Value.TargetId, $"{roamingA.Key.Id}");
+                Guard.IsNotNull(roamingA.Value.Sources.FirstOrDefault(x=> x == localA.Key.Id));
+            }
+            {
+                // Publish provided default values to created keys
+                var localACid = await clientA.Dag.PutAsync(localA.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await clientA.Name.PublishAsync(localACid, localA.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+                
+                var roamingACid = await clientA.Dag.PutAsync(roamingA.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await clientA.Name.PublishAsync(roamingACid, roamingA.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+            }
+            
+            // Only create local key for nodeB, roaming key will be imported from nodeA.
+            var localB = await GetOrCreateLocalStorageKeyAsyc(localKeyName, folderId, roamingKey: roamingA.Key, kuboOptions, clientB, cancellationToken);
+            {
+                // Default value validation
+                Guard.IsEqualTo(localB.Value.TargetId, $"{roamingA.Key.Id}");
+            }
+
+            // Execute pairing
+            {
+                // Generate pairing code
+                var pairingCode = Guid.NewGuid().ToString().Split('-')[0];
+                Guard.HasSizeGreaterThanOrEqualTo(pairingCode, 8);
+                
+                // Split 8 digits into 2x4, room name and password.
+                var roomName = string.Join(null, pairingCode.Take(4));
+                var password = string.Join(null, pairingCode.Skip(4));
+                
+                // Initiate pairing from node a and follow up on nodeB
+                var nodeAPairingTask = EncryptedPubSubNomadPairAsync(kuboA, kuboOptions, clientA, kuboA.Client, localA.Key, isRoamingReceiver: false, roamingKeyName, roomName, password, cancellationToken); 
+                var nodeBPairingTask = EncryptedPubSubNomadPairAsync(kuboB, kuboOptions, clientB, kuboB.Client, localB.Key, isRoamingReceiver: true, roamingKeyName, roomName, password, cancellationToken);
+            
+                await Task.WhenAll(nodeAPairingTask, nodeBPairingTask);
+            }
+            
+            // Verify published roaming keys
+            {
+                var enumerableKeysB = await clientB.Key.ListAsync(cancellationToken);
+                var keysB = enumerableKeysB as IKey[] ?? enumerableKeysB.ToArray();
+                
+                // roamingA should be imported and present in keysB
+                var roamingBKey = keysB.FirstOrDefault(x => x.Id == roamingA.Key.Id);
+                Guard.IsNotNull(roamingBKey);
+                
+                // Verify published roaming data from perspective of both A and B.
+                var publishedRoamingAOnA = await ResolveAndValidatePublishedRoamingSeedAsync(clientA, roamingA.Key, kuboOptions, cancellationToken);
+                var publishedRoamingAOnB = await ResolveAndValidatePublishedRoamingSeedAsync(clientB, roamingA.Key, kuboOptions, cancellationToken);
+                
+                var publishedRoamingBOnA = await ResolveAndValidatePublishedRoamingSeedAsync(clientA, roamingBKey, kuboOptions, cancellationToken);
+                var publishedRoamingBOnB = await ResolveAndValidatePublishedRoamingSeedAsync(clientB, roamingBKey, kuboOptions, cancellationToken);
+                
+                // Roaming was just imported from A to B, all data should be identical.
+                Guard.IsEqualTo(publishedRoamingAOnA.StorableItemId, publishedRoamingAOnB.StorableItemId);
+                Guard.IsEqualTo(publishedRoamingAOnA.StorableItemName, publishedRoamingAOnB.StorableItemName);
+                Guard.IsTrue(publishedRoamingAOnA.Sources.SequenceEqual(publishedRoamingAOnB.Sources));
+                
+                Guard.IsEqualTo(publishedRoamingBOnA.StorableItemId, publishedRoamingBOnB.StorableItemId);
+                Guard.IsEqualTo(publishedRoamingBOnA.StorableItemName, publishedRoamingBOnB.StorableItemName);
+                Guard.IsTrue(publishedRoamingBOnA.Sources.SequenceEqual(publishedRoamingBOnB.Sources));
+                
+                // Given above grid of checks
+                // (AOnA, AOnB)
+                // (BOnA, BOnB)
+                // Cross 1,1 with 2,2 (AOnA, BOnB)
+                Guard.IsEqualTo(publishedRoamingAOnA.StorableItemId, publishedRoamingBOnB.StorableItemId);
+                Guard.IsEqualTo(publishedRoamingAOnA.StorableItemName, publishedRoamingBOnB.StorableItemName);
+                Guard.IsTrue(publishedRoamingAOnA.Sources.SequenceEqual(publishedRoamingBOnB.Sources));
+                
+                // Cross 2,1 with 1,2 (BOnA, AOnB)
+                Guard.IsEqualTo(publishedRoamingBOnA.StorableItemId, publishedRoamingAOnB.StorableItemId);
+                Guard.IsEqualTo(publishedRoamingBOnA.StorableItemName, publishedRoamingAOnB.StorableItemName);
+                Guard.IsTrue(publishedRoamingBOnA.Sources.SequenceEqual(publishedRoamingAOnB.Sources));
+            }
+            
+            // Verify published local data
+            var (publishedLocalAOnA, _) = await clientA.ResolveDagCidAsync<EventStream<Cid>>(localA.Key.Id, !kuboOptions.UseCache, cancellationToken);
+            Guard.IsNotNull(publishedLocalAOnA);
+            {
+                // Load event stream entries
+                (EventStreamEntry<Cid>? eventStreamEntry, Cid eventStreamEntryCid)[] eventStreamEntries = await publishedLocalAOnA.Entries.InParallel(x => clientA.ResolveDagCidAsync<EventStreamEntry<Cid>>(x, nocache: !kuboOptions.UseCache, cancellationToken));
+                Guard.IsNotEmpty(eventStreamEntries);
+                
+                var sourceAddEventStreamEntries = eventStreamEntries
+                    .Where(x => x.eventStreamEntry?.EventId == nameof(SourceAddEvent))
+                    .Where(x=> x.eventStreamEntry is not null)
+                    .Cast<(EventStreamEntry<Cid> eventStreamEntry, Cid eventStreamEntryCid)>()
+                    .ToArray();
+                Guard.IsNotEmpty(sourceAddEventStreamEntries);
+                
+                var sourceAddEventUpdates = await sourceAddEventStreamEntries.InParallel(x => clientA.ResolveDagCidAsync<SourceAddEvent>(x.eventStreamEntry.Content, nocache: !kuboOptions.UseCache, cancellationToken));
+                Guard.IsNotEmpty(sourceAddEventUpdates);
+                
+                // Ensure localB is added to localA's event stream in a SourceAddEvent
+                var localBSourceAddEventUpdate = sourceAddEventUpdates
+                    .Where(x=> x.Result is not null)
+                    .Cast<(SourceAddEvent SourceAddEvent, Cid SourceAddEventCid)>()
+                    .FirstOrDefault(x=> x.SourceAddEvent.AddedSourcePointer == localB.Key.Id);
+                
+                Guard.IsNotNull(localBSourceAddEventUpdate.SourceAddEvent);
+            }
+        }
+        
+        await kuboA.Client.ShutdownAsync();
+        kuboA.Dispose();
+        
+        await kuboB.Client.ShutdownAsync();
+        kuboB.Dispose();
+        
+        Guard.IsTrue(kuboA.Process?.HasExited ?? true);
+        Guard.IsTrue(kuboB.Process?.HasExited ?? true);
+        Logger.MessageReceived -= LoggerOnMessageReceived;
+    }
+}

--- a/tests/KuboNomadFolderTests.Push.cs
+++ b/tests/KuboNomadFolderTests.Push.cs
@@ -1,0 +1,133 @@
+﻿using System.Diagnostics;
+using CommunityToolkit.Diagnostics;
+using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.Kubo;
+using OwlCore.Kubo.Cache;
+using OwlCore.Nomad.Kubo;
+using OwlCore.Nomad.Storage.Models;
+using OwlCore.Storage.System.IO;
+using OwlCore.Diagnostics;
+using OwlCore.Extensions;
+using OwlCore.Nomad.Kubo.Events;
+using OwlCore.Nomad.Storage.Kubo.Tests.Extensions;
+using OwlCore.Storage;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests;
+
+public partial class KuboNomadFolderTests
+{
+    [TestMethod]
+    public async Task PushTestAsync()
+    {
+        Logger.MessageReceived += LoggerOnMessageReceived;
+        var cancellationToken = CancellationToken.None;
+
+        var temp = new SystemFolder(Path.GetTempPath());
+        var testTempFolder = await SafeCreateFolderAsync(temp, $"{nameof(KuboNomadFolderTests)}.{nameof(PushTestAsync)}", cancellationToken);
+        var kubo = await BootstrapKuboAsync(testTempFolder, 5012, 8012, cancellationToken);
+        var kuboOptions = new KuboOptions
+        {
+            IpnsLifetime = TimeSpan.FromDays(1),
+            ShouldPin = false,
+            UseCache = false,
+        };
+        
+        {
+            var folderToPush = (SystemFolder)await testTempFolder.CreateFolderAsync("in", cancellationToken: cancellationToken);
+            await foreach (var file in folderToPush.CreateFilesAsync(5, i => $"{i}", cancellationToken))
+                await file.WriteRandomBytes(numberOfBytes: 4096, cancellationToken);
+            
+            var folderId = nameof(PushTestAsync);
+
+            var client = kubo.Client;
+            var (local, roaming) = await CreateStorageKeysAsync($"Nomad.Storage.Local.{folderId}", $"Nomad.Storage.Roaming.{folderId}", folderId, folderId, client, cancellationToken);
+            {
+                // Default value validation.
+                // roaming should be the TargetId on local,
+                // local should be a source on roaming.
+                Guard.IsEqualTo(local.Value.TargetId, $"{roaming.Key.Id}");
+                Guard.IsNotNull(roaming.Value.Sources.FirstOrDefault(x=> x == local.Key.Id));
+            }
+            {
+                // Publish provided default values to created keys
+                var localACid = await client.Dag.PutAsync(local.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await client.Name.PublishAsync(localACid, local.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+                
+                var roamingACid = await client.Dag.PutAsync(roaming.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await client.Name.PublishAsync(roamingACid, roaming.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+            }
+            
+            {
+                var sharedEventStreamHandlers = new List<ISharedEventStreamHandler<Cid, EventStream<Cid>, EventStreamEntry<Cid>>>();
+                var nomadFolder = new KuboNomadFolder(sharedEventStreamHandlers)
+                {
+                    Inner = roaming.Value,
+                    AllEventStreamEntries = [], // Must call ResolveEventStreamEntriesAsync to populate all entries
+                    EventStreamHandlerId = roaming.Key.Id,
+                    RoamingKey = roaming.Key,
+                    LocalEventStreamKey = local.Key,
+                    LocalEventStream = local.Value,
+                    Sources = roaming.Value.Sources,
+                    Client = client,
+                    KuboOptions = kuboOptions,
+                    Parent = null,
+                };
+                
+                // Push and Publish
+                await folderToPush.CopyToAsync(nomadFolder, storable => GetLastWriteTimeFor(storable, nomadFolder.AllEventStreamEntries), cancellationToken);
+                {
+                    var localACid = await client.Dag.PutAsync(nomadFolder.LocalEventStream, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                    _ = await client.Name.PublishAsync(localACid, local.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+                
+                    var roamingACid = await client.Dag.PutAsync(nomadFolder.Inner, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                    _ = await client.Name.PublishAsync(roamingACid, roaming.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+                }
+                
+                // Cleanup and reload
+                {
+                    await nomadFolder.ResetEventStreamPositionAsync(cancellationToken);
+                    nomadFolder.AllEventStreamEntries.Clear();
+                    
+                    // Roaming keys are published from multiple nodes.
+                    // If we're publishing this roaming key, we cannot read the latest published by another node, we must build from sources.
+                    await foreach (var entry in nomadFolder.ResolveEventStreamEntriesAsync(cancellationToken).OrderBy(x => x.TimestampUtc))
+                    {
+                        Guard.IsNotNull(entry.TimestampUtc);
+                        nomadFolder.AllEventStreamEntries.Add(entry);
+                 
+                        // Advance stream handler.
+                        if (nomadFolder.Id == entry.TargetId)
+                            await nomadFolder.AdvanceEventStreamAsync(entry, cancellationToken);
+                    }
+                }
+                
+                // Verify folder contents
+                {
+                    Guard.IsNotEmpty(nomadFolder.AllEventStreamEntries);
+                    Guard.IsNotEmpty(nomadFolder.LocalEventStream.Entries);
+                    var sourceFiles = await folderToPush.GetFilesAsync(cancellationToken: cancellationToken).OrderBy(x => x.Name).ToListAsync(cancellationToken);
+                    var pushedFiles = await nomadFolder.GetFilesAsync(cancellationToken: cancellationToken).OrderBy(x => x.Name).ToListAsync(cancellationToken);
+
+                    Guard.IsGreaterThan(sourceFiles.Count, 0);
+                    Guard.IsGreaterThan(pushedFiles.Count, 0);
+                    
+                    foreach (var pushedFile in pushedFiles)
+                    {
+                        var sourceFile = sourceFiles.First(x => x.Name == pushedFile.Name);
+
+                        var pushedFileBytes = await pushedFile.ReadBytesAsync(cancellationToken);
+                        var sourceFileBytes = await sourceFile.ReadBytesAsync(cancellationToken);
+                        CollectionAssert.AreEqual(pushedFileBytes, sourceFileBytes);
+                    }
+                }
+            }
+        }
+
+        await kubo.Client.ShutdownAsync();
+        kubo.Dispose();
+        await SetAllFileAttributesRecursive(testTempFolder, attributes => attributes & ~FileAttributes.ReadOnly);
+        await temp.DeleteAsync(testTempFolder, cancellationToken);
+        Logger.MessageReceived -= LoggerOnMessageReceived;
+    }
+}

--- a/tests/KuboNomadFolderTests.PushPull.SingleNode.cs
+++ b/tests/KuboNomadFolderTests.PushPull.SingleNode.cs
@@ -1,0 +1,109 @@
+﻿using System.Diagnostics;
+using CommunityToolkit.Diagnostics;
+using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.Kubo;
+using OwlCore.Kubo.Cache;
+using OwlCore.Nomad.Kubo;
+using OwlCore.Nomad.Storage.Models;
+using OwlCore.Storage.System.IO;
+using OwlCore.Diagnostics;
+using OwlCore.Extensions;
+using OwlCore.Nomad.Kubo.Events;
+using OwlCore.Nomad.Storage.Kubo.Tests.Extensions;
+using OwlCore.Storage;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests;
+
+public partial class KuboNomadFolderTests
+{
+    [TestMethod]
+    public async Task PushPullSingleNodeTestAsync()
+    {
+        Logger.MessageReceived += LoggerOnMessageReceived;
+        var cancellationToken = CancellationToken.None;
+
+        var temp = new SystemFolder(Path.GetTempPath());
+        var testTempFolder = await SafeCreateFolderAsync(temp, $"{nameof(KuboNomadFolderTests)}.{nameof(PushPullSingleNodeTestAsync)}", cancellationToken);
+        var kubo = await BootstrapKuboAsync(testTempFolder, 5013, 8013, cancellationToken);
+        var kuboOptions = new KuboOptions
+        {
+            IpnsLifetime = TimeSpan.FromDays(1),
+            ShouldPin = false,
+            UseCache = false,
+        };
+
+        {
+            var folderToPush = (SystemFolder)await testTempFolder.CreateFolderAsync("in", cancellationToken: cancellationToken);
+            var folderToPull = (SystemFolder)await testTempFolder.CreateFolderAsync("out", cancellationToken: cancellationToken);
+            
+            await foreach (var file in folderToPush.CreateFilesAsync(5, i => $"{i}", cancellationToken))
+                await file.WriteRandomBytes(numberOfBytes: 4096, cancellationToken);
+
+            var folderId = nameof(PushPullSingleNodeTestAsync);
+            var localKeyName = $"Nomad.Storage.Local.{folderId}";
+            var roamingKeyName = $"Nomad.Storage.Roaming.{folderId}";
+
+            var client = kubo.Client;
+            var (local, roaming) = await CreateStorageKeysAsync(localKeyName, roamingKeyName, folderId, folderId, client, cancellationToken);
+            {
+                // Default value validation.
+                // roaming should be the TargetId on local,
+                // local should be a source on roaming.
+                Guard.IsEqualTo(local.Value.TargetId, $"{roaming.Key.Id}");
+                Guard.IsNotNull(roaming.Value.Sources.FirstOrDefault(x=> x == local.Key.Id));
+            }
+            {
+                // Publish provided default values to created keys
+                var localACid = await client.Dag.PutAsync(local.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await client.Name.PublishAsync(localACid, local.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+                
+                var roamingACid = await client.Dag.PutAsync(roaming.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await client.Name.PublishAsync(roamingACid, roaming.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+            }
+            
+            // Roaming keys are published from multiple nodes.
+            // If we're publishing this roaming key, we cannot read the latest published by another node, we must build from sources.
+            var sharedEventStreamHandlers = new List<ISharedEventStreamHandler<Cid, EventStream<Cid>, EventStreamEntry<Cid>>>();
+            var nomadFolder = new KuboNomadFolder(sharedEventStreamHandlers)
+            {
+                Inner = roaming.Value,
+                AllEventStreamEntries = [], // Must call ResolveEventStreamEntriesAsync to populate all entries
+                EventStreamHandlerId = roaming.Key.Id,
+                RoamingKey = roaming.Key,
+                LocalEventStreamKey = local.Key,
+                LocalEventStream = local.Value,
+                Sources = roaming.Value.Sources,
+                Client = client,
+                KuboOptions = kuboOptions,
+                Parent = null,
+            };
+            
+            await folderToPush.CopyToAsync(nomadFolder, storable => GetLastWriteTimeFor(storable, nomadFolder.AllEventStreamEntries), cancellationToken);
+            
+            await nomadFolder.CopyToAsync(folderToPull, storable => GetLastWriteTimeFor(storable, nomadFolder.AllEventStreamEntries), cancellationToken);
+            
+            // Verify folder contents
+            var pushedFiles = await folderToPush.GetFilesAsync(cancellationToken: cancellationToken).OrderBy(x => x.Name).ToListAsync(cancellationToken: cancellationToken);
+            var pulledFiles = await folderToPull.GetFilesAsync(cancellationToken: cancellationToken).OrderBy(x => x.Name).ToListAsync(cancellationToken: cancellationToken);
+
+            Guard.IsGreaterThan(pushedFiles.Count, 0);
+            Guard.IsGreaterThan(pulledFiles.Count, 0);
+
+            foreach (var pushedFile in pushedFiles)
+            {
+                var pulledFile = pulledFiles.First(x => x.Name == pushedFile.Name);
+
+                var pushedFileBytes = await pushedFile.ReadBytesAsync(cancellationToken);
+                var pulledFileBytes = await pulledFile.ReadBytesAsync(cancellationToken);
+                CollectionAssert.AreEqual(pushedFileBytes, pulledFileBytes);
+            }
+        }
+
+        await kubo.Client.ShutdownAsync();
+        kubo.Dispose();
+        await SetAllFileAttributesRecursive(testTempFolder, attributes => attributes & ~FileAttributes.ReadOnly);
+        await temp.DeleteAsync(testTempFolder, cancellationToken);
+        Logger.MessageReceived -= LoggerOnMessageReceived;
+    }
+}

--- a/tests/KuboNomadFolderTests.PushPull.TwoNodes.cs
+++ b/tests/KuboNomadFolderTests.PushPull.TwoNodes.cs
@@ -1,0 +1,208 @@
+﻿using CommunityToolkit.Diagnostics;
+using Ipfs;
+using OwlCore.Kubo;
+using OwlCore.Nomad.Kubo;
+using OwlCore.Storage.System.IO;
+using OwlCore.Diagnostics;
+using OwlCore.Nomad.Storage.Kubo.Tests.Extensions;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests;
+
+public partial class KuboNomadFolderTests
+{
+    [TestMethod]
+    public async Task PushPullPairedTwoNodeTestAsync()
+    {
+        Logger.MessageReceived += LoggerOnMessageReceived;
+        var cancellationToken = CancellationToken.None;
+
+        var temp = new SystemFolder(Path.GetTempPath());
+        var testTempFolder = await SafeCreateFolderAsync(temp, $"{nameof(KuboNomadFolderTests)}.{nameof(PushPullPairedTwoNodeTestAsync)}", cancellationToken);
+        var kuboOptions = new KuboOptions
+        {
+            IpnsLifetime = TimeSpan.FromDays(1),
+            ShouldPin = false,
+            UseCache = false,
+        };
+        
+        // Spawn kubo nodes
+        var nodeAFolder = (SystemFolder)await testTempFolder.CreateFolderAsync("node-a", overwrite: true, cancellationToken); 
+        var kuboA = await BootstrapKuboAsync(nodeAFolder, 5014, 8014, cancellationToken);
+        
+        var nodeBFolder = (SystemFolder)await testTempFolder.CreateFolderAsync("node-b", overwrite: true, cancellationToken);
+        var kuboB = await BootstrapKuboAsync(nodeBFolder, 5015, 8015, cancellationToken);
+        
+        // Connect kubo nodes in swarm
+        await AddPeerToSwarmAsync(kuboA.Client, kuboB.Client, cancellationToken);
+        await AddPeerToSwarmAsync(kuboB.Client, kuboA.Client, cancellationToken);
+
+        var clientA = kuboA.Client;
+        var clientB = kuboB.Client;
+        {
+            var sourceFolder = (SystemFolder)await testTempFolder.CreateFolderAsync("in", cancellationToken: cancellationToken);
+            var destinationFolder = (SystemFolder)await testTempFolder.CreateFolderAsync("out", cancellationToken: cancellationToken);
+            
+            // Add new content to source, to be pushed via A and pulled via B 
+            await foreach (var file in sourceFolder.CreateFilesAsync(5, i => $"pushedFromA.{i}", cancellationToken))
+                await file.WriteRandomBytes(numberOfBytes: 4096, cancellationToken);
+            
+            var folderId = nameof(PairingTestAsync);
+            var roamingKeyName = $"Nomad.Storage.Roaming.{folderId}";
+            var localKeyName = $"Nomad.Storage.Local.{folderId}";
+
+            // Create local AND roaming keys for nodeA.
+            // During pairing, roamingA will be exported to nodeB, and localB will be added to the event stream for localA.
+            var (localA, roamingA) = await CreateStorageKeysAsync(localKeyName, roamingKeyName, folderId, folderId, clientA, cancellationToken);
+            {
+                // Default value validation.
+                // roaming should be the TargetId on local,
+                // local should be a source on roaming.
+                Guard.IsEqualTo(localA.Value.TargetId, $"{roamingA.Key.Id}");
+                Guard.IsNotNull(roamingA.Value.Sources.FirstOrDefault(x => x == localA.Key.Id));
+            }
+            {
+                // Publish provided default values to created keys
+                var localACid = await clientA.Dag.PutAsync(localA.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await clientA.Name.PublishAsync(localACid, localA.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+
+                var roamingACid = await clientA.Dag.PutAsync(roamingA.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                _ = await clientA.Name.PublishAsync(roamingACid, roamingA.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+            }
+
+            // Only create local key for nodeB, roaming key will be imported from nodeA.
+            var localB = await GetOrCreateLocalStorageKeyAsyc(localKeyName, folderId, roamingKey: roamingA.Key, kuboOptions, clientB, cancellationToken);
+            {
+                // Default value validation
+                Guard.IsEqualTo(localB.Value.TargetId, $"{roamingA.Key.Id}");
+            }
+
+            // Execute pairing
+            {
+                // Generate pairing code
+                var pairingCode = Guid.NewGuid().ToString().Split('-')[0];
+                Guard.HasSizeGreaterThanOrEqualTo(pairingCode, 8);
+
+                // Split 8 digits into 2x4, room name and password.
+                var roomName = string.Join(null, pairingCode.Take(4));
+                var password = string.Join(null, pairingCode.Skip(4));
+
+                // Initiate pairing from node a and follow up on nodeB
+                var nodeAPairingTask = EncryptedPubSubNomadPairAsync(kuboA, kuboOptions, clientA, kuboA.Client, localA.Key, isRoamingReceiver: false, roamingKeyName, roomName, password, cancellationToken);
+                var nodeBPairingTask = EncryptedPubSubNomadPairAsync(kuboB, kuboOptions, clientB, kuboB.Client, localB.Key, isRoamingReceiver: true, roamingKeyName, roomName, password, cancellationToken);
+
+                await Task.WhenAll(nodeAPairingTask, nodeBPairingTask);
+            
+                // Reload updated local data
+                var (publishedLocalAOnA, _) = await clientA.ResolveDagCidAsync<EventStream<Cid>>(localA.Key.Id, !kuboOptions.UseCache, cancellationToken);
+                Guard.IsNotNull(publishedLocalAOnA);
+                localA.Value = publishedLocalAOnA;
+            }
+            
+            {
+                var enumerableKeysB = await clientB.Key.ListAsync(cancellationToken);
+                var keysB = enumerableKeysB as IKey[] ?? enumerableKeysB.ToArray();
+                    
+                // roamingA should be imported and present in keysB
+                var roamingBKey = keysB.FirstOrDefault(x => x.Id == roamingA.Key.Id);
+                Guard.IsNotNull(roamingBKey);
+                var publishedRoamingBOnB = await ResolveAndValidatePublishedRoamingSeedAsync(clientB, roamingBKey, kuboOptions, cancellationToken);
+
+                var sharedEventStreamHandlersA = new List<ISharedEventStreamHandler<Cid, EventStream<Cid>, EventStreamEntry<Cid>>>();
+                var nomadFolderA = new KuboNomadFolder(sharedEventStreamHandlersA)
+                {
+                    Inner = roamingA.Value,
+                    AllEventStreamEntries = [], // Must call ResolveEventStreamEntriesAsync to populate all entries
+                    EventStreamHandlerId = roamingA.Key.Id,
+                    RoamingKey = roamingA.Key,
+                    LocalEventStreamKey = localA.Key,
+                    LocalEventStream = localA.Value,
+                    Sources = roamingA.Value.Sources,
+                    Client = clientA,
+                    KuboOptions = kuboOptions,
+                    Parent = null,
+                };
+                
+                var sharedEventStreamHandlersB = new List<ISharedEventStreamHandler<Cid, EventStream<Cid>, EventStreamEntry<Cid>>>();
+                var nomadFolderB = new KuboNomadFolder(sharedEventStreamHandlersB)
+                {
+                    Inner = publishedRoamingBOnB,
+                    AllEventStreamEntries = [], // Must call ResolveEventStreamEntriesAsync to populate all entries
+                    EventStreamHandlerId = roamingBKey.Id,
+                    RoamingKey = roamingBKey,
+                    LocalEventStreamKey = localB.Key,
+                    LocalEventStream = localB.Value,
+                    Sources = publishedRoamingBOnB.Sources,
+                    Client = clientB,
+                    KuboOptions = kuboOptions,
+                    Parent = null,
+                };
+                
+                // Push via A
+                {
+                    await sourceFolder.CopyToAsync(nomadFolderA, storable => GetLastWriteTimeFor(storable, nomadFolderA.AllEventStreamEntries), cancellationToken);
+                        
+                    // Publish changes
+                    var localACid = await clientA.Dag.PutAsync(localA.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                    _ = await clientA.Name.PublishAsync(localACid, localA.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+                }
+                
+                // Pull via B
+                {
+                    // Roaming keys are published from multiple nodes.
+                    // If we're publishing this roaming key, we cannot read the latest published by another node, we must build from sources.
+                    await foreach (var entry in nomadFolderB.ResolveEventStreamEntriesAsync(cancellationToken).OrderBy(x => x.TimestampUtc))
+                    {
+                        Guard.IsNotNull(entry.TimestampUtc);
+                        nomadFolderB.AllEventStreamEntries.Add(entry);
+                 
+                        // Advance stream handler.
+                        if (nomadFolderB.Id == entry.TargetId)
+                            await nomadFolderB.AdvanceEventStreamAsync(entry, cancellationToken);
+                    }
+            
+                    await nomadFolderB.CopyToAsync(destinationFolder, storable => GetLastWriteTimeFor(storable, nomadFolderB.AllEventStreamEntries), cancellationToken);
+                }
+            
+                // Verify folder contents
+                await VerifyFolderContents(sourceFolder, destinationFolder, cancellationToken);
+                
+                // Push via B
+                {
+                    // Add new content to dest, to be pushed via B and pulled via A
+                    await foreach (var file in destinationFolder.CreateFilesAsync(5, i => $"pushedFromB.{i}", cancellationToken))
+                        await file.WriteRandomBytes(numberOfBytes: 4096, cancellationToken);
+                    
+                    await destinationFolder.CopyToAsync(nomadFolderB, storable => GetLastWriteTimeFor(storable, nomadFolderB.AllEventStreamEntries), cancellationToken);
+                        
+                    // Publish changes
+                    var localBCid = await clientB.Dag.PutAsync(localB.Value, cancel: cancellationToken, pin: kuboOptions.ShouldPin);
+                    _ = await clientB.Name.PublishAsync(localBCid, localB.Key.Name, lifetime: kuboOptions.IpnsLifetime, cancellationToken);
+                }
+                
+                // Pull via A
+                {
+                    // Roaming keys are published from multiple nodes.
+                    // If we're publishing this roaming key, we cannot read the latest published by another node, we must build from sources.
+                    await foreach (var entry in nomadFolderA.ResolveEventStreamEntriesAsync(cancellationToken).OrderBy(x => x.TimestampUtc))
+                    {
+                        Guard.IsNotNull(entry.TimestampUtc);
+                        nomadFolderA.AllEventStreamEntries.Add(entry);
+                 
+                        // Advance stream handler.
+                        if (nomadFolderA.Id == entry.TargetId)
+                            await nomadFolderA.AdvanceEventStreamAsync(entry, cancellationToken);
+                    }
+                    
+                    Guard.IsNotNull(nomadFolderA.Sources.FirstOrDefault(x => x == localB.Key.Id));
+                    Guard.IsNotNull(nomadFolderA.Sources.FirstOrDefault(x => x == localA.Key.Id));
+                    Guard.IsEqualTo(nomadFolderA.Sources.Count, 2);
+            
+                    await nomadFolderA.CopyToAsync(sourceFolder, storable => GetLastWriteTimeFor(storable, nomadFolderA.AllEventStreamEntries), cancellationToken);
+                }
+            
+                // Verify folder contents
+                await VerifyFolderContents(sourceFolder, destinationFolder, cancellationToken);
+            }
+        }
+    }
+}

--- a/tests/KuboNomadFolderTests.cs
+++ b/tests/KuboNomadFolderTests.cs
@@ -1,0 +1,230 @@
+﻿using System.Diagnostics;
+using CommunityToolkit.Diagnostics;
+using Ipfs;
+using Ipfs.CoreApi;
+using OwlCore.Kubo;
+using OwlCore.Kubo.Cache;
+using OwlCore.Nomad.Kubo;
+using OwlCore.Nomad.Storage.Models;
+using OwlCore.Storage.System.IO;
+using OwlCore.Diagnostics;
+using OwlCore.Extensions;
+using OwlCore.Nomad.Kubo.Events;
+using OwlCore.Nomad.Storage.Kubo.Tests.Extensions;
+using OwlCore.Storage;
+
+namespace OwlCore.Nomad.Storage.Kubo.Tests;
+
+[TestClass]
+public partial class KuboNomadFolderTests
+{
+    private void LoggerOnMessageReceived(object? sender, LoggerMessageEventArgs args)
+    {
+        Debug.WriteLine(args.Message);
+    }
+
+    private async Task VerifyFolderContents(SystemFolder sourceFolder, SystemFolder destinationFolder, CancellationToken cancellationToken)
+    {
+        var pushedFiles = await sourceFolder.GetFilesAsync(cancellationToken: cancellationToken).OrderBy(x => x.Name).ToListAsync(cancellationToken: cancellationToken);
+        var pulledFiles = await destinationFolder.GetFilesAsync(cancellationToken: cancellationToken).OrderBy(x => x.Name).ToListAsync(cancellationToken: cancellationToken);
+
+        Guard.IsGreaterThan(pushedFiles.Count, 0);
+        Guard.IsGreaterThan(pulledFiles.Count, 0);
+        Guard.IsEqualTo(pushedFiles.Count, pulledFiles.Count);
+
+        foreach (var pushedFile in pushedFiles)
+        {
+            var pulledFile = pulledFiles.First(x => x.Name == pushedFile.Name);
+
+            var pushedFileBytes = await pushedFile.ReadBytesAsync(cancellationToken);
+            var pulledFileBytes = await pulledFile.ReadBytesAsync(cancellationToken);
+            CollectionAssert.AreEqual(pushedFileBytes, pulledFileBytes);
+        }
+    }
+
+    private static async Task AddPeerToSwarmAsync(IGenericApi clientA, ICoreApi clientB, CancellationToken cancellationToken)
+    {
+        var peerB = await clientA.IdAsync(cancel: cancellationToken);
+        foreach (var address in peerB.Addresses)
+        {
+            try
+            {
+                await clientB.Swarm.ConnectAsync(address, cancellationToken);
+            }
+            catch
+            {
+                // ignored
+            }
+        }
+    }
+
+    private static async Task<NomadFolderData<Cid>> ResolveAndValidatePublishedRoamingSeedAsync(ICoreApi client, IKey roamingKey, KuboOptions kuboOptions, CancellationToken cancellationToken)
+    {
+        var (publishedRoaming, _) = await client.ResolveDagCidAsync<NomadFolderData<Cid>>(roamingKey.Id, nocache: !kuboOptions.UseCache, cancellationToken);
+        Guard.IsNotNull(publishedRoaming);
+        {
+            Guard.IsNotEmpty(publishedRoaming.Sources);
+            Guard.IsNotNullOrWhiteSpace(publishedRoaming.StorableItemId);
+            Guard.IsNotNullOrWhiteSpace(publishedRoaming.StorableItemName);
+            Guard.IsEmpty(publishedRoaming.Files);
+            Guard.IsEmpty(publishedRoaming.Folders);
+        }
+        return publishedRoaming;
+    }
+
+    public async Task EncryptedPubSubNomadPairAsync(KuboBootstrapper kubo, IKuboOptions kuboOptions, ICoreApi client, IGenericApi genericApi, IKey localKey, bool isRoamingReceiver, string roamingKeyName, string roomName, string password, CancellationToken cancellationToken = default)
+    {
+        // Setup encrypted pubsub
+        var thisPeer = await genericApi.IdAsync(cancel: cancellationToken);
+        var encryptedPubSub = new AesPasswordEncryptedPubSub(client.PubSub, password, salt: roomName);
+        using var peerRoom = new PeerRoom(thisPeer, encryptedPubSub, $"{roomName}")
+        {
+            HeartbeatEnabled = false,
+        };
+        
+        // Local key must be initialized prior to pairing
+        // Roaming key must exist on the 'roaming sender' node, must not exist on 'roaming receiver' node.
+        // The node that receives a roaming key should be a sender for local key, and vice versa.
+        await KeyExchange.ExchangeRoamingKeyAsync(peerRoom, roamingKeyName, isReceiver: isRoamingReceiver, kubo, kuboOptions, client, cancellationToken);
+
+        // The node that sends a roaming key should be receiver for local key, and vice versa.
+        var isLocalReceiver = !isRoamingReceiver;
+        await KeyExchange.ExchangeLocalSourceAsync(peerRoom, localKey, roamingKeyName, isReceiver: isLocalReceiver, kuboOptions, client, cancellationToken);
+    }
+
+    public static DateTime GetLastWriteTimeFor(IStorable storable, IEnumerable<EventStreamEntry<Cid>> eventStreamEntries)
+    {
+        return storable switch
+        {
+            KuboNomadFile nFile => eventStreamEntries.Where(x => x.TargetId == nFile.Id).Max(x => x.TimestampUtc) ?? ThrowHelper.ThrowNotSupportedException<DateTime>("Unhandled code path"),
+            KuboNomadFolder nFolder => eventStreamEntries.Where(x => x.TargetId == nFolder.Id).Max(x => x.TimestampUtc) ?? ThrowHelper.ThrowNotSupportedException<DateTime>("Unhandled code path"),
+            ReadOnlyKuboNomadFile nFile => eventStreamEntries.Where(x => x.TargetId == nFile.Id).Max(x => x.TimestampUtc) ?? ThrowHelper.ThrowNotSupportedException<DateTime>("Unhandled code path"),
+            ReadOnlyKuboNomadFolder nFolder => eventStreamEntries.Where(x => x.TargetId == nFolder.Id).Max(x => x.TimestampUtc) ?? ThrowHelper.ThrowNotSupportedException<DateTime>("Unhandled code path"),
+            SystemFolder systemFolder => systemFolder.Info.LastWriteTimeUtc,
+            SystemFile systemFile => systemFile.Info.LastWriteTimeUtc,
+            _ => throw new ArgumentOutOfRangeException(nameof(storable), storable, null)
+        };
+    }
+    
+    /// <summary>
+    /// Creates a temp folder for the test fixture to work in, safely unlocking and removing existing files if needed.
+    /// </summary>
+    /// <returns>The folder that was created.</returns>
+    public static async Task<SystemFolder> SafeCreateFolderAsync(SystemFolder rootFolder, string name, CancellationToken cancellationToken)
+    {
+        // When Kubo is stopped unexpectedly, it may leave some files with a ReadOnly attribute.
+        // Since this folder is created every time tests are run, we need to clean up any files leftover from prior runs.
+        // To do that, we need to remove the ReadOnly file attribute.
+        var testTempRoot = (SystemFolder)await rootFolder.CreateFolderAsync(name, overwrite: false, cancellationToken: cancellationToken);
+        await SetAllFileAttributesRecursive(testTempRoot, attributes => attributes & ~FileAttributes.ReadOnly);
+
+        // Delete and recreate the folder.
+        return (SystemFolder)await rootFolder.CreateFolderAsync(name, overwrite: true, cancellationToken: cancellationToken);
+    }
+    
+    /// <summary>
+    /// Changes the file attributes of all files in all subfolders of the provided <see cref="SystemFolder"/>.
+    /// </summary>
+    /// <param name="rootFolder">The folder to set file permissions in.</param>
+    /// <param name="transform">This function is provided the current file attributes, and should return the new file attributes.</param>
+    public static async Task SetAllFileAttributesRecursive(SystemFolder rootFolder, Func<FileAttributes, FileAttributes> transform)
+    {
+        await foreach (var childFile in rootFolder.GetFilesAsync())
+        {
+            var file = (SystemFile)childFile;
+            file.Info.Attributes = transform(file.Info.Attributes);
+        }
+
+        await foreach (var childFolder in rootFolder.GetFoldersAsync())
+        {
+            var folder = (SystemFolder)childFolder;
+            await SetAllFileAttributesRecursive(folder, transform);
+        }
+    }
+    
+    private static async Task<KuboBootstrapper> BootstrapKuboAsync(SystemFolder kuboRepo, int apiPort, int gatewayPort, CancellationToken cancellationToken)
+    {
+        var kubo = new KuboBootstrapper(kuboRepo.Path)
+        {
+            ApiUri = new Uri($"http://127.0.0.1:{apiPort}"),
+            GatewayUri = new Uri($"http://127.0.0.1:{gatewayPort}"),
+            RoutingMode = DhtRoutingMode.None,
+            LaunchConflictMode = BootstrapLaunchConflictMode.Attach,
+            ApiUriMode = ConfigMode.OverwriteExisting,
+            GatewayUriMode = ConfigMode.OverwriteExisting,
+        };
+                
+        await kubo.StartAsync(cancellationToken);
+        return kubo;
+    }
+    
+    private async Task<CachedCoreApi> CreateCachedClientAsync(KuboBootstrapper kubo, CancellationToken cancellationToken)
+    {
+        var cacheFolder = (SystemFolder)await kubo.RepoFolder.CreateFolderAsync(".cache", overwrite: false, cancellationToken: cancellationToken);
+        var cacheLayer = new CachedCoreApi(cacheFolder, kubo.Client);
+
+        await cacheLayer.InitAsync(cancellationToken);
+        return cacheLayer;
+    }
+
+    /// <summary>
+    /// Creates roaming and local storage keys and yields a default recommended value, but does not publish the value to the newly created keys.
+    /// </summary>
+    /// <param name="localKeyName">The name of the local key to create.</param>
+    /// <param name="roamingKeyName">The name of the roaming key to create.</param>
+    /// <param name="nomadFolderName">The root folder name to use in the roaming data.</param>
+    /// <param name="eventStreamLabel">The label to use for the created local event stream.</param>
+    /// <param name="client">A client to use for communicating with ipfs.</param>
+    /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
+    private async Task<((IKey Key, EventStream<Cid> Value) LocalKey, (IKey Key, NomadFolderData<Cid> Value) RoamingKey)> CreateStorageKeysAsync(string localKeyName, string roamingKeyName, string nomadFolderName, string eventStreamLabel, ICoreApi client, CancellationToken cancellationToken)
+    {
+        // Get or create ipns key
+        var enumerableKeys = await client.Key.ListAsync(cancellationToken);
+        var keys = enumerableKeys as IKey[] ?? enumerableKeys.ToArray();
+
+        var localKey = keys.FirstOrDefault(x => x.Name == localKeyName);
+        var roamingKey = keys.FirstOrDefault(x => x.Name == roamingKeyName);
+        
+        // Key should not be created yet
+        Guard.IsNull(localKey);
+        Guard.IsNull(roamingKey);
+        
+        localKey = await client.Key.CreateAsync(localKeyName, "ed25519", size: 4096, cancellationToken);
+        roamingKey = await client.Key.CreateAsync(roamingKeyName, "ed25519", size: 4096, cancellationToken);
+
+        // Get default value and cid
+        // ---
+        // Roaming should not be exported/imported without including at least one local source,
+        // otherwise we'd have an extra step exporting local separately from roaming from A to B.
+        // ---
+        // This is also retroactively handled when publishing an event stream to roaming, but we're only defining the seed values here.
+        var defaultLocalValue = new EventStream<Cid>
+        {
+            Label = eventStreamLabel,
+            TargetId = roamingKey.Id,
+            Entries = [],
+        };
+
+        var defaultRoamingValue = new NomadFolderData<Cid>
+        {
+            StorableItemId = roamingKey.Id,
+            StorableItemName = nomadFolderName,
+            Files = [],
+            Folders = [],
+            Sources = [localKey.Id],
+        };
+
+        return ((localKey, defaultLocalValue), (roamingKey, defaultRoamingValue));
+    }
+
+    private static Task<(IKey Key, EventStream<Cid> Value)> GetOrCreateLocalStorageKeyAsyc(string localKeyName, string eventStreamLabel, IKey roamingKey, KuboOptions kuboOptions, ICoreApi client, CancellationToken cancellationToken)
+    {
+        // Local key should contain an empty event stream with the roaming key as the targetid
+        return client.GetOrCreateKeyAsync(localKeyName, _ => new EventStream<Cid>
+        {
+            Label = eventStreamLabel,
+            TargetId = roamingKey.Id, 
+            Entries = [],
+        }, kuboOptions.IpnsLifetime, nocache: !kuboOptions.UseCache, size: 4096, cancellationToken);
+    }
+}

--- a/tests/OwlCore.Nomad.Storage.Kubo.Tests.csproj
+++ b/tests/OwlCore.Nomad.Storage.Kubo.Tests.csproj
@@ -9,9 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="3.3.1" />
-    <PackageReference Include="MSTest.TestFramework" Version="3.3.1" />
+    <PackageReference Include="Ignore" Version="0.2.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.5.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.5.2" />
     <PackageReference Include="coverlet.collector" Version="6.0.2" />
     <PackageReference Include="OwlCore" Version="0.6.0" />
   </ItemGroup>


### PR DESCRIPTION
Release 0.8.0

[Breaking]
Inherited and implemented breaking changes from OwlCore.Nomad 0.8.0.
KuboBasedNomadStorageExtensions.TryAdvanceEventStream now takes IModifiableKuboNomadFile or IModifiableKuboNomadFolder as the 'this' param.
KuboNomadFolder still uses the event stream handler from OwlCore.Noamd.Storage.NomadFolder, but ReadOnlyKuboNomadFolder uses roaming data directly and does not use an event stream handler. 
KuboBasedNomadStorageExtensions.ApplyFolderUpdateAsync and KuboBasedNomadStorageExtensions.ApplyFileUpdateAsync were removed as they are now handled by the underlying NomadFolder implementation.

[Fixes]
Fixed an issue with WritableNomadFileStream where a race condition + bad stream seeking would cause empty content to be flushed to Kubo.

[Improvements]
Ported and refined prototype CLI code to build out a test suite for this implementation, which helped clear up most of the remaining inconsistencies around Nomad as a whole.
Generally, the library no longer auto-publishes to Kubo for you, instead holding the data in memory and sharing across instances. The constructor caller is expected to know when and why to flush roaming or local data to Kubo. 
