### PR TITLE
Release 0.15.0

### DIFF
--- a/src/Extensions/NomadKuboStorageExtensions.cs
+++ b/src/Extensions/NomadKuboStorageExtensions.cs
@@ -22,7 +22,7 @@ public static class NomadKuboStorageExtensions
     /// <param name="eventEntry">The event entry to apply to the given <paramref name="file"/>.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <exception cref="InvalidOperationException">Raised when the <see cref="EventStreamEntry{TContentPointer}.TargetId"/> doesn't match the <see cref="OwlCore.Storage.IStorable.Id"/> of the provided <paramref name="file"/>.</exception>
-    public static async Task TryAdvanceEventStreamAsync(this IModifiableNomadKuboFile file, EventStreamEntry<Cid> eventEntry, CancellationToken cancellationToken)
+    public static async Task TryAdvanceEventStreamAsync(this IModifiableNomadKuboFile file, EventStreamEntry<DagCid> eventEntry, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         
@@ -45,7 +45,7 @@ public static class NomadKuboStorageExtensions
     /// <param name="eventEntry">The event entry to apply to the given <paramref name="folder"/>.</param>
     /// <param name="cancellationToken">A token that can be used to cancel the ongoing operation.</param>
     /// <exception cref="InvalidOperationException">Raised when the <see cref="EventStreamEntry{TContentPointer}.TargetId"/> doesn't match the <see cref="OwlCore.Storage.IStorable.Id"/> of the provided <paramref name="folder"/>.</exception>
-    public static async Task TryAdvanceEventStreamAsync(this IModifiableNomadKuboFolder folder, EventStreamEntry<Cid> eventEntry, CancellationToken cancellationToken)
+    public static async Task TryAdvanceEventStreamAsync(this IModifiableNomadKuboFolder folder, EventStreamEntry<DagCid> eventEntry, CancellationToken cancellationToken)
     {
         cancellationToken.ThrowIfCancellationRequested();
         
@@ -60,7 +60,7 @@ public static class NomadKuboStorageExtensions
         if (updateEvent?.WorkingFolderId != folder.Id)
             throw new InvalidOperationException($"The provided {nameof(updateEvent)} isn't designated for this folder and can't be applied.");
 
-        await folder.ApplyEntryUpdateAsync(updateEvent, cancellationToken);
+        await folder.ApplyEntryUpdateAsync(eventEntry, updateEvent, cancellationToken);
         folder.EventStreamPosition = eventEntry;
         Diagnostics.Logger.LogInformation($"Advanced event stream for folder {folder.Id} with {eventEntry.EventId} content {eventEntry.Content}");
     }

--- a/src/IReadOnlyNomadKuboFile.cs
+++ b/src/IReadOnlyNomadKuboFile.cs
@@ -8,6 +8,6 @@ namespace OwlCore.Nomad.Storage.Kubo;
 /// <summary>
 /// A kubo-based storage interface for files.
 /// </summary>
-public interface IReadOnlyNomadKuboFile : IChildFile, IDelegable<NomadFileData<Cid>>
+public interface IReadOnlyNomadKuboFile : IChildFile, IDelegable<NomadFileData<DagCid>>
 {
 }

--- a/src/IReadOnlyNomadKuboFolder.cs
+++ b/src/IReadOnlyNomadKuboFolder.cs
@@ -11,6 +11,6 @@ namespace OwlCore.Nomad.Storage.Kubo;
 /// <remarks>
 /// Primarily use to create extension method helpers between file/folder implementations of the generic base classes.
 /// </remarks>
-public interface IReadOnlyNomadKuboFolder : IChildFolder, IMutableFolder, IDelegable<NomadFolderData<Cid>>
+public interface IReadOnlyNomadKuboFolder : IChildFolder, IMutableFolder, IDelegable<NomadFolderData<DagCid, Cid>>
 {
 }

--- a/src/Models/FileUpdateEvent.cs
+++ b/src/Models/FileUpdateEvent.cs
@@ -8,4 +8,4 @@ namespace OwlCore.Nomad.Storage.Kubo.Models;
 /// <param name="StorableItemId">The id of the file that was changed.</param>
 /// <param name="NewContentId">A Cid that represents immutable content. The same ID should always point to the same content, and different content should point to different Ids.</param>
 /// <param name="EventId">A unique identifier for this type of event.</param>
-public record FileUpdateEvent(string StorableItemId, Cid NewContentId, string EventId = nameof(FileUpdateEvent));
+public record FileUpdateEvent(string StorableItemId, DagCid NewContentId, string EventId = nameof(FileUpdateEvent));

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -14,16 +14,22 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.14.0</Version>
+		<Version>0.15.0</Version>
 		<Product>OwlCore</Product>
 		<Description>A storage implementation powered by Nomad event sourcing on ipfs/Kubo.</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Storage.Kubo</PackageProjectUrl>
 		<PackageReleaseNotes>
+--- 0.15.0 ---
+[Breaking]
+Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0 and OwlCore.Nomad.Storage 0.10.0.
+Code has been updated to use Cid and DagCid for TImmutablePointer and TMutablePointer, respectively. This is a breaking change for all types that implement these interfaces.
+Existing event streams will need to be recreated or migrated to the new format, if any. 
+
 --- 0.14.0 ---
 [Breaking]
-Inherited and implemented breaking changes from OwlCore.Nomad 0.9.0 and OwlCore.Nomad.Storage 0.14.0.
+Inherited and implemented breaking changes from OwlCore.Nomad 0.9.0 and OwlCore.Nomad.Storage 0.9.0.
 All types that were using *KuboNomad* are now using *NomadKubo*. This reflects the namespace of the type and will be a consistent pattern moving forward.
 
 [New]
@@ -199,8 +205,6 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
-	    <PackageReference Include="OwlCore.Nomad.Storage" Version="0.9.0" />
-	    <PackageReference Include="OwlCore.Nomad.Kubo" Version="0.14.0" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
 		  <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
@@ -213,5 +217,10 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
+	</ItemGroup>
+
+	<ItemGroup>
+	  <ProjectReference Include="..\..\ocnomadkubo\src\OwlCore.Nomad.Kubo.csproj" />
+	  <ProjectReference Include="..\..\ocnomadstorage\src\OwlCore.Nomad.Storage.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -203,7 +203,9 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.0" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
+		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.15.0" />
+		<PackageReference Include="OwlCore.Nomad.Storage" Version="0.10.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="PolySharp" Version="1.14.1">
 		  <PrivateAssets>all</PrivateAssets>
@@ -217,10 +219,5 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 	    <Pack>True</Pack>
 	    <PackagePath>\</PackagePath>
 	  </None>
-	</ItemGroup>
-
-	<ItemGroup>
-	  <ProjectReference Include="..\..\ocnomadkubo\src\OwlCore.Nomad.Kubo.csproj" />
-	  <ProjectReference Include="..\..\ocnomadstorage\src\OwlCore.Nomad.Storage.csproj" />
 	</ItemGroup>
 </Project>

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -16,7 +16,7 @@
 		<Author>Arlo Godfrey</Author>
 		<Version>0.15.0</Version>
 		<Product>OwlCore</Product>
-		<Description>A storage implementation powered by Nomad event sourcing on ipfs/Kubo.</Description>
+		<Description>A storage implementation powered by event stream sourcing on IPFS via Kubo</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Storage.Kubo</PackageProjectUrl>

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -23,7 +23,7 @@
 		<PackageReleaseNotes>
 --- 0.15.0 ---
 [Breaking]
-Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0 and OwlCore.Nomad.Storage 0.10.0.
+Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0, OwlCore.Nomad.Storage 0.10.0 and OwlCore.Nomad.Kubo 0.15.0.
 Code has been updated to use Cid and DagCid for TImmutablePointer and TMutablePointer, respectively. This is a breaking change for all types that implement these interfaces.
 Existing event streams will need to be recreated or migrated to the new format, if any. 
 
@@ -204,7 +204,7 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
-		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.15.0" />
+		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.15.1" />
 		<PackageReference Include="OwlCore.Nomad.Storage" Version="0.10.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="PolySharp" Version="1.14.1">

--- a/src/ReadOnlyNomadKuboFile.cs
+++ b/src/ReadOnlyNomadKuboFile.cs
@@ -15,7 +15,7 @@ namespace OwlCore.Nomad.Storage.Kubo;
 /// <summary>
 /// A virtual file constructed by reading the roaming <see cref="NomadFileData{TContentPointer}"/> published by another node.
 /// </summary>
-public class ReadOnlyNomadKuboFile : IChildFile, IDelegable<NomadFileData<Cid>>
+public class ReadOnlyNomadKuboFile : IChildFile, IDelegable<NomadFileData<DagCid>>
 {
     /// <summary>
     /// The client to use for communicating with ipfs/kubo.
@@ -29,7 +29,7 @@ public class ReadOnlyNomadKuboFile : IChildFile, IDelegable<NomadFileData<Cid>>
     public string Name => Inner.StorableItemName;
 
     /// <inheritdoc />
-    public required NomadFileData<Cid> Inner { get; init; }
+    public required NomadFileData<DagCid> Inner { get; init; }
 
     /// <summary>
     /// The parent for this folder, if any.

--- a/src/ReadOnlyNomadKuboFolder.cs
+++ b/src/ReadOnlyNomadKuboFolder.cs
@@ -13,9 +13,9 @@ using OwlCore.Storage;
 namespace OwlCore.Nomad.Storage.Kubo;
 
 /// <summary>
-/// A virtual folder constructed by reading the roaming <see cref="NomadFolderData{TContentPointer}"/> published by another node.
+/// A virtual folder constructed by reading the roaming <see cref="NomadFolderData{TImmutablePointer, TMutablePointer}"/> published by another node.
 /// </summary>
-public class ReadOnlyNomadKuboFolder : IChildFolder, IDelegable<NomadFolderData<Cid>>, IGetRoot
+public class ReadOnlyNomadKuboFolder : IChildFolder, IDelegable<NomadFolderData<DagCid, Cid>>, IGetRoot
 {
     /// <summary>
     /// Creates a new instance of <see cref="ReadOnlyNomadKuboFolder"/> from the given handler configuration.
@@ -23,7 +23,7 @@ public class ReadOnlyNomadKuboFolder : IChildFolder, IDelegable<NomadFolderData<
     /// <param name="handlerConfig">The handler configuration to use.</param>
     /// <param name="client">A client that can be used for accessing ipfs.</param>
     /// <returns>A new instance of <see cref="ReadOnlyNomadKuboFolder"/>.</returns>
-    public static ReadOnlyNomadKuboFolder FromHandlerConfig(NomadKuboEventStreamHandlerConfig<NomadFolderData<Cid>> handlerConfig, ICoreApi client)
+    public static ReadOnlyNomadKuboFolder FromHandlerConfig(NomadKuboEventStreamHandlerConfig<NomadFolderData<DagCid, Cid>> handlerConfig, ICoreApi client)
     {
         Guard.IsNotNull(handlerConfig.RoamingValue);
         Guard.IsNotNull(handlerConfig.RoamingId);
@@ -49,7 +49,7 @@ public class ReadOnlyNomadKuboFolder : IChildFolder, IDelegable<NomadFolderData<
     public string Name => Inner.StorableItemName;
 
     /// <inheritdoc />
-    public required NomadFolderData<Cid> Inner { get; init; }
+    public required NomadFolderData<DagCid, Cid> Inner { get; init; }
 
     /// <summary>
     /// The parent for this folder, if any.

--- a/src/StorageRepoFactory.cs
+++ b/src/StorageRepoFactory.cs
@@ -23,9 +23,9 @@ public static class StorageRepoFactory
     /// <param name="kuboOptions">The options used to read and write data to and from Kubo.</param>
     /// <param name="folderName">The name of the folder to ues, if not already set.</param>
     /// <returns>A repository for managing peer swarms.</returns>
-    public static NomadKuboRepository<NomadKuboFolder, IFolder, NomadFolderData<Cid>, FolderUpdateEvent> GetFolderRepository(string roamingKeyName, string localKeyName, string folderName, IModifiableFolder tempCacheFolder, ICoreApi client, IKuboOptions kuboOptions)
+    public static NomadKuboRepository<NomadKuboFolder, IFolder, NomadFolderData<DagCid, Cid>, FolderUpdateEvent> GetFolderRepository(string roamingKeyName, string localKeyName, string folderName, IModifiableFolder tempCacheFolder, ICoreApi client, IKuboOptions kuboOptions)
     {
-        return new NomadKuboRepository<NomadKuboFolder, IFolder, NomadFolderData<Cid>, FolderUpdateEvent>
+        return new NomadKuboRepository<NomadKuboFolder, IFolder, NomadFolderData<DagCid, Cid>, FolderUpdateEvent>
         {
             DefaultEventStreamLabel = $"Folder {folderName}",
             Client = client,
@@ -33,7 +33,7 @@ public static class StorageRepoFactory
             GetEventStreamHandlerConfigAsync = async (roamingId, cancellationToken) =>
             {
                 var (localKey, roamingKey, foundRoamingId) = await NomadKeyHelpers.RoamingIdToNomadKeysAsync(roamingId, roamingKeyName, localKeyName, client, cancellationToken);
-                return new NomadKuboEventStreamHandlerConfig<NomadFolderData<Cid>>
+                return new NomadKuboEventStreamHandlerConfig<NomadFolderData<DagCid, Cid>>
                 {
                     RoamingId = roamingKey?.Id ?? (foundRoamingId is not null ? Cid.Decode(foundRoamingId) : null),
                     RoamingKey = roamingKey,
@@ -42,7 +42,7 @@ public static class StorageRepoFactory
                     LocalKeyName = localKeyName,
                 };
             },
-            GetDefaultRoamingValue = (localKey, roamingKey) => new NomadFolderData<Cid>
+            GetDefaultRoamingValue = (localKey, roamingKey) => new NomadFolderData<DagCid, Cid>
             {
                 StorableItemId = roamingKey.Id,
                 StorableItemName = folderName,

--- a/tests/KuboNomadFolderTests.Pair.cs
+++ b/tests/KuboNomadFolderTests.Pair.cs
@@ -120,7 +120,7 @@ public partial class NomadKuboFolderTests
                 Guard.IsNotEmpty(eventStreamEntries);
                 
                 var sourceAddEventStreamEntries = eventStreamEntries
-                    .Where(x => x.eventStreamEntry?.EventId == "SourceAddEvent")
+                    .Where(x => x.eventStreamEntry?.EventId == ReservedEventIds.NomadEventStreamSourceAdd)
                     .Where(x=> x.eventStreamEntry is not null)
                     .Cast<(EventStreamEntry<DagCid> eventStreamEntry, DagCid eventStreamEntryCid)>()
                     .ToArray();

--- a/tests/KuboNomadFolderTests.Pair.cs
+++ b/tests/KuboNomadFolderTests.Pair.cs
@@ -116,11 +116,11 @@ public partial class NomadKuboFolderTests
             Guard.IsNotNull(publishedLocalAOnA);
             {
                 // Load event stream entries
-                (EventStreamEntry<DagCid>? eventStreamEntry, DagCid eventStreamEntryCid)[] eventStreamEntries = await publishedLocalAOnA.Entries.InParallel(x => clientA.ResolveDagCidAsync<EventStreamEntry<DagCid>>(x, nocache: !kuboOptions.UseCache, cancellationToken));
+                (EventStreamEntry<DagCid>? eventStreamEntry, Cid eventStreamEntryCid)[] eventStreamEntries = await publishedLocalAOnA.Entries.InParallel(x => clientA.ResolveDagCidAsync<EventStreamEntry<DagCid>>(x, nocache: !kuboOptions.UseCache, cancellationToken));
                 Guard.IsNotEmpty(eventStreamEntries);
                 
                 var sourceAddEventStreamEntries = eventStreamEntries
-                    .Where(x => x.eventStreamEntry?.EventId == ReservedEventIds.NomadEventStreamSourceAdd)
+                    .Where(x => x.eventStreamEntry?.EventId == ReservedEventIds.NomadEventStreamSourceAddEvent)
                     .Where(x=> x.eventStreamEntry is not null)
                     .Cast<(EventStreamEntry<DagCid> eventStreamEntry, DagCid eventStreamEntryCid)>()
                     .ToArray();
@@ -132,9 +132,9 @@ public partial class NomadKuboFolderTests
                 // Ensure localB is added to localA's event stream in a SourceAddEvent
                 var localBSourceAddEventUpdate = sourceAddEventUpdates
                     .Where(x=> x.Result is not null)
-                    .FirstOrDefault(x => x == localB.Key.Id);
+                    .FirstOrDefault(x => x.Result == localB.Key.Id);
                 
-                Guard.IsNotNull(localBSourceAddEventUpdate.SourceAddEvent);
+                Guard.IsNotNull(localBSourceAddEventUpdate.Result);
             }
         }
         

--- a/tests/KuboNomadFolderTests.Pair.cs
+++ b/tests/KuboNomadFolderTests.Pair.cs
@@ -116,24 +116,23 @@ public partial class NomadKuboFolderTests
             Guard.IsNotNull(publishedLocalAOnA);
             {
                 // Load event stream entries
-                (EventStreamEntry<Cid>? eventStreamEntry, Cid eventStreamEntryCid)[] eventStreamEntries = await publishedLocalAOnA.Entries.InParallel(x => clientA.ResolveDagCidAsync<EventStreamEntry<Cid>>(x, nocache: !kuboOptions.UseCache, cancellationToken));
+                (EventStreamEntry<DagCid>? eventStreamEntry, DagCid eventStreamEntryCid)[] eventStreamEntries = await publishedLocalAOnA.Entries.InParallel(x => clientA.ResolveDagCidAsync<EventStreamEntry<DagCid>>(x, nocache: !kuboOptions.UseCache, cancellationToken));
                 Guard.IsNotEmpty(eventStreamEntries);
                 
                 var sourceAddEventStreamEntries = eventStreamEntries
-                    .Where(x => x.eventStreamEntry?.EventId == nameof(SourceAddEvent))
+                    .Where(x => x.eventStreamEntry?.EventId == "SourceAddEvent")
                     .Where(x=> x.eventStreamEntry is not null)
-                    .Cast<(EventStreamEntry<Cid> eventStreamEntry, Cid eventStreamEntryCid)>()
+                    .Cast<(EventStreamEntry<DagCid> eventStreamEntry, DagCid eventStreamEntryCid)>()
                     .ToArray();
                 Guard.IsNotEmpty(sourceAddEventStreamEntries);
                 
-                var sourceAddEventUpdates = await sourceAddEventStreamEntries.InParallel(x => clientA.ResolveDagCidAsync<SourceAddEvent>(x.eventStreamEntry.Content, nocache: !kuboOptions.UseCache, cancellationToken));
+                var sourceAddEventUpdates = await sourceAddEventStreamEntries.InParallel(x => clientA.ResolveDagCidAsync<Cid>(x.eventStreamEntry.Content, nocache: !kuboOptions.UseCache, cancellationToken));
                 Guard.IsNotEmpty(sourceAddEventUpdates);
                 
                 // Ensure localB is added to localA's event stream in a SourceAddEvent
                 var localBSourceAddEventUpdate = sourceAddEventUpdates
                     .Where(x=> x.Result is not null)
-                    .Cast<(SourceAddEvent SourceAddEvent, Cid SourceAddEventCid)>()
-                    .FirstOrDefault(x=> x.SourceAddEvent.AddedSourcePointer == localB.Key.Id);
+                    .FirstOrDefault(x => x == localB.Key.Id);
                 
                 Guard.IsNotNull(localBSourceAddEventUpdate.SourceAddEvent);
             }

--- a/tests/KuboNomadFolderTests.Pair.cs
+++ b/tests/KuboNomadFolderTests.Pair.cs
@@ -112,7 +112,7 @@ public partial class NomadKuboFolderTests
             }
             
             // Verify published local data
-            var (publishedLocalAOnA, _) = await clientA.ResolveDagCidAsync<EventStream<Cid>>(folderA.LocalEventStreamKey.Id, !kuboOptions.UseCache, cancellationToken);
+            var (publishedLocalAOnA, _) = await clientA.ResolveDagCidAsync<EventStream<DagCid>>(folderA.LocalEventStreamKey.Id, !kuboOptions.UseCache, cancellationToken);
             Guard.IsNotNull(publishedLocalAOnA);
             {
                 // Load event stream entries

--- a/tests/KuboNomadFolderTests.PushPull.TwoNodes.cs
+++ b/tests/KuboNomadFolderTests.PushPull.TwoNodes.cs
@@ -97,7 +97,7 @@ public partial class NomadKuboFolderTests
                 await Task.WhenAll(nodeAPairingTask, nodeBPairingTask);
 
                 // Reload updated local data
-                var (publishedLocalAOnA, _) = await clientA.ResolveDagCidAsync<EventStream<Cid>>(nomadFolderA.LocalEventStreamKey.Id, !kuboOptions.UseCache, cancellationToken);
+                var (publishedLocalAOnA, _) = await clientA.ResolveDagCidAsync<EventStream<DagCid>>(nomadFolderA.LocalEventStreamKey.Id, !kuboOptions.UseCache, cancellationToken);
                 Guard.IsNotNull(publishedLocalAOnA);
                 nomadFolderA.LocalEventStream = publishedLocalAOnA;
                 nomadFolderAHandlerConfig.LocalValue = publishedLocalAOnA;

--- a/tests/KuboNomadFolderTests.cs
+++ b/tests/KuboNomadFolderTests.cs
@@ -116,7 +116,7 @@ public partial class NomadKuboFolderTests
         return publishedRoaming;
     }
 
-    public static DateTime GetLastWriteTimeFor(IStorable storable, IEnumerable<EventStreamEntry<Cid>> eventStreamEntries)
+    public static DateTime GetLastWriteTimeFor(IStorable storable, IEnumerable<EventStreamEntry<DagCid>> eventStreamEntries)
     {
         return storable switch
         {

--- a/tests/KuboNomadFolderTests.cs
+++ b/tests/KuboNomadFolderTests.cs
@@ -102,9 +102,9 @@ public partial class NomadKuboFolderTests
         }
     }
 
-    private static async Task<NomadFolderData<Cid>> ResolveAndValidatePublishedRoamingSeedAsync(ICoreApi client, IKey roamingKey, KuboOptions kuboOptions, CancellationToken cancellationToken)
+    private static async Task<NomadFolderData<DagCid, Cid>> ResolveAndValidatePublishedRoamingSeedAsync(ICoreApi client, IKey roamingKey, KuboOptions kuboOptions, CancellationToken cancellationToken)
     {
-        var (publishedRoaming, _) = await client.ResolveDagCidAsync<NomadFolderData<Cid>>(roamingKey.Id, nocache: !kuboOptions.UseCache, cancellationToken);
+        var (publishedRoaming, _) = await client.ResolveDagCidAsync<NomadFolderData<DagCid, Cid>>(roamingKey.Id, nocache: !kuboOptions.UseCache, cancellationToken);
         Guard.IsNotNull(publishedRoaming);
         {
             Guard.IsNotEmpty(publishedRoaming.Sources);


### PR DESCRIPTION
[Breaking]
- Inherited and implemented breaking changes from OwlCore.Nomad 0.10.0, OwlCore.Nomad.Storage 0.10.0 and OwlCore.Nomad.Kubo 0.15.0.
- Code has been updated to use Cid and DagCid for TImmutablePointer and TMutablePointer, respectively. This is a breaking change for all types that implement these interfaces.
- Existing event streams will need to be recreated or migrated to the new format, if any. 