### PR TITLE
Release 0.17.0

### DIFF
--- a/src/NomadKuboFolder.cs
+++ b/src/NomadKuboFolder.cs
@@ -45,7 +45,7 @@ public class NomadKuboFolder : NomadFolder<DagCid, Cid, EventStream<DagCid>, Eve
             EventStreamHandlerId = handlerConfig.RoamingKey.Id,
             Inner = handlerConfig.RoamingValue,
             RoamingKey = handlerConfig.RoamingKey,
-            Sources = handlerConfig.RoamingValue.Sources,
+            Sources = handlerConfig.Sources,
             LocalEventStreamKey = handlerConfig.LocalKey,
             LocalEventStream = handlerConfig.LocalValue,
             ResolvedEventStreamEntries = handlerConfig.ResolvedEventStreamEntries,

--- a/src/OwlCore.Nomad.Storage.Kubo.csproj
+++ b/src/OwlCore.Nomad.Storage.Kubo.csproj
@@ -14,13 +14,19 @@
 		<AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
 
 		<Author>Arlo Godfrey</Author>
-		<Version>0.16.0</Version>
+		<Version>0.17.0</Version>
 		<Product>OwlCore</Product>
 		<Description>A storage implementation powered by event stream sourcing on IPFS via Kubo</Description>
 		<PackageLicenseFile>LICENSE.txt</PackageLicenseFile>
 		<PackageIcon>logo.png</PackageIcon>
 		<PackageProjectUrl>https://github.com/Arlodotexe/OwlCore.Nomad.Storage.Kubo</PackageProjectUrl>
 		<PackageReleaseNotes>
+[Breaking]
+Inherited breaking changes from OwlCore.Nomad.Kubo 0.17.0, none to implement.
+
+[Improvements]
+KuboNomadFolder now pulls sources from NomadKuboEventStreamHandlerConfig{T}.Sources instead of the Roaming value.
+
 --- 0.16.0 ---
 [Breaking]
 Inherited and implemented breaking changes from OwlCore.Nomad.Kubo 0.16.0
@@ -209,7 +215,7 @@ Initial release of OwlCore.Nomad.Storage.Kubo.
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="9.0.2" />
-		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.16.0" />
+		<PackageReference Include="OwlCore.Nomad.Kubo" Version="0.17.0" />
 		<PackageReference Include="OwlCore.Nomad.Storage" Version="0.10.0" />
 		<PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
 		<PackageReference Include="PolySharp" Version="1.14.1">

--- a/tests/KuboNomadFolderTests.Pair.cs
+++ b/tests/KuboNomadFolderTests.Pair.cs
@@ -51,7 +51,8 @@ public partial class NomadKuboFolderTests
                 KuboOptions = kuboOptions,
                 TempCacheFolder = nodeACacheFolder,
                 KeyNamePrefix = "Nomad.Storage",
-                ManagedKeys = nodeAKeys.ToList(),
+                ManagedKeys = nodeAKeys.Select(k => new Key(k)).ToList(),
+                ManagedConfigs = [],
             };
             
             var folderA = await localARepo.CreateAsync(folderId, cancellationToken);

--- a/tests/KuboNomadFolderTests.Push.cs
+++ b/tests/KuboNomadFolderTests.Push.cs
@@ -50,9 +50,10 @@ public partial class NomadKuboFolderTests
                 KuboOptions = kuboOptions,
                 TempCacheFolder = cacheFolder,
                 KeyNamePrefix = "Nomad.Storage",
-                ManagedKeys = nodeAKeys.ToList(),
+                ManagedKeys = nodeAKeys.Select(k => new Key(k)).ToList(),
+                ManagedConfigs = [],
             };
-                
+
             var nomadFolder = await localARepo.CreateAsync(folderId, cancellationToken);
 
             {

--- a/tests/KuboNomadFolderTests.PushPull.SingleNode.cs
+++ b/tests/KuboNomadFolderTests.PushPull.SingleNode.cs
@@ -57,7 +57,8 @@ public partial class NomadKuboFolderTests
                 KuboOptions = kuboOptions,
                 TempCacheFolder = cacheFolder,
                 KeyNamePrefix = "Nomad.Storage",
-                ManagedKeys = nodeAKeys.ToList(),
+                ManagedKeys = nodeAKeys.Select(k => new Key(k)).ToList(),
+                ManagedConfigs = [],
             };
             
             var nomadFolder = await localARepo.CreateAsync(folderId, cancellationToken);


### PR DESCRIPTION
[Breaking]
Inherited breaking changes from OwlCore.Nomad.Kubo 0.17.0, none to implement.

[Improvements]
KuboNomadFolder now pulls sources from NomadKuboEventStreamHandlerConfig{T}.Sources instead of the Roaming value.